### PR TITLE
[Idea] Make the helper able to update through Everest

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -33,7 +33,7 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       run: |
         ZIPNAME=$ZIPNAME-${GITHUB_SHA:0:8}.zip
-        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Ahorn Graphics
+        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Ahorn Dialog Graphics
         url=$(curl -H 'Content-Type: multipart/form-data' -X POST -F "file=@$ZIPNAME" "$DISCORD_WEBHOOK" | grep -Po 'cdn.discordapp.com\/.*?\.zip' | tr -d '\n')
         msg=$(git log -n 1 "--format=%B" | head -n 1 | tr -d '\n')
         curl -H 'Content-Type: application/json' -X POST -d "$(jq -n \

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -1,0 +1,2 @@
+# Auto-formatting is "Strawberry Jam2021"
+modname_StrawberryJam2021= Strawberry Jam 2021

--- a/SelfUpdater.cs
+++ b/SelfUpdater.cs
@@ -1,0 +1,43 @@
+﻿using Celeste.Mod.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Celeste.Mod.StrawberryJam2021 {
+    /// <summary>
+    /// "Self-updater" is probably an overstatement, since this effectively just adds an extra "update source" to the Everest mod updater.
+    /// The rest of updating is handled by Everest itself.
+    /// </summary>
+    static class SelfUpdater {
+        public static void Load() {
+            On.Celeste.Mod.Helpers.ModUpdaterHelper.DownloadModUpdateList += onDownloadModUpdateList;
+        }
+
+        public static void Unload() {
+            On.Celeste.Mod.Helpers.ModUpdaterHelper.DownloadModUpdateList -= onDownloadModUpdateList;
+        }
+
+        private static Dictionary<string, ModUpdateInfo> onDownloadModUpdateList(On.Celeste.Mod.Helpers.ModUpdaterHelper.orig_DownloadModUpdateList orig) {
+            Dictionary<string, ModUpdateInfo> updateCatalog = orig();
+
+            if (updateCatalog != null) {
+                try {
+                    // download a Strawberry Jam-specific everest_update.yaml, and add it to the mod updater database.
+                    using (WebClient wc = new WebClient()) {
+                        string yamlData = wc.DownloadString("https://storage.googleapis.com/max480-random-stuff.appspot.com/strawberry_jam_extra_everest_update.yaml");
+                        Dictionary<string, ModUpdateInfo> extraUpdateCatalog = YamlHelper.Deserializer.Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
+                        foreach (string name in extraUpdateCatalog.Keys) {
+                            extraUpdateCatalog[name].Name = name;
+                            updateCatalog[name] = extraUpdateCatalog[name];
+                        }
+                        Logger.Log("StrawberryJam2021/SelfUpdater", $"Downloaded {extraUpdateCatalog.Count} extra item(s), total: {updateCatalog.Count}");
+                    }
+                } catch (Exception) {
+                    // Don't worry about it. The file will be taken down later on anyway.
+                }
+            }
+
+            return updateCatalog;
+        }
+    }
+}

--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -8,9 +8,11 @@
         }
 
         public override void Load() {
+            SelfUpdater.Load();
         }
 
         public override void Unload() {
+            SelfUpdater.Unload();
         }
 
     }


### PR DESCRIPTION
I thought it would be a good thing to have, to ensure mappers keep their helper up-to-date. 🤔 

How it works is that I made a bot monitor the #coding_updates channel and react to any uploading of a file named StrawberryJam2021-[anything].zip. When this happens, the bot pushes out a file formatted like Everest's everest_update.yaml on Google Cloud Storage. When it's done doing this, the bot reacts with ✅ on the file.

There is no self-updating logic here. When Everest downloads the database, it is also going to download the file uploaded by the bot and merge both. Then Strawberry Jam 2021 is checked for updates and (auto-)updated like any mod. That's it. 😅 