### PR TITLE
Fix the .csproj reference paths and make them configurable

### DIFF
--- a/StrawberryJam2021.csproj
+++ b/StrawberryJam2021.csproj
@@ -7,6 +7,7 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
 
     <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.exe')">..\..</CelestePrefix>
+    <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
     <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelestePrefix)\BuildIsXNA.txt')">XNA</CelesteType>
     <CelesteType Condition="'$(CelesteType)' == ''">FNA</CelesteType>
     <XNAPath Condition="'$(XNAPath)' == ''">$(WINDIR)\Microsoft.NET\assembly\GAC_32\{0}\v4.0_4.0.0.0__842cf8be1de50553\{0}.dll</XNAPath>


### PR DESCRIPTION
This PR replaces the huge conditional branching in the .csproj with dynamic properties and a simpler conditional branch. This is much less prone to failure and can be overridden using `dotnet build ..... /p:PropName=Value .....`