### PR TITLE
Include Audio folder in autobuilds

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -33,7 +33,7 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       run: |
         ZIPNAME=$ZIPNAME-${GITHUB_SHA:0:8}.zip
-        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Ahorn Dialog Graphics
+        zip -qq -r $ZIPNAME everest.yaml bin/Debug/net452 Audio Ahorn Dialog Graphics
         url=$(curl -H 'Content-Type: multipart/form-data' -X POST -F "file=@$ZIPNAME" "$DISCORD_WEBHOOK" | grep -Po 'cdn.discordapp.com\/.*?\.zip' | tr -d '\n')
         msg=$(git log -n 1 "--format=%B" | head -n 1 | tr -d '\n')
         curl -H 'Content-Type: application/json' -X POST -d "$(jq -n \


### PR DESCRIPTION
Audio should ship in the helper zip, so this PR makes the build bot zip it along with Graphics, Ahorn, Dialog and the built DLL.