### PR TITLE
Add Masked Foreground Decals

### DIFF
--- a/Ahorn/entities/maskedDecal.jl
+++ b/Ahorn/entities/maskedDecal.jl
@@ -1,0 +1,54 @@
+module SJ2021MaskedDecal
+
+using ..Ahorn, Maple
+
+@mapdef Entity "SJ2021/MaskedDecal" MaskedDecal(x::Integer, y::Integer, texture::String="", scaleX::Number=1.0, scaleY::Number=1.0)
+
+const placements = Ahorn.PlacementDict(
+    "Masked Decal (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        MaskedDecal
+    )
+)
+
+function Ahorn.selection(entity::MaskedDecal)
+    x, y = Ahorn.position(entity)
+    sprite = "decals/$(get(entity, "texture", ""))"
+    scaleX = get(entity, "scaleX", 1.0)
+    scaleY = get(entity, "scaleY", 1.0)
+
+    return Ahorn.getSpriteRectangle(sprite, x, y, sx=scaleX, sy=scaleY)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::MaskedDecal, room::Maple.Room)
+    sprite = "decals/$(get(entity, "texture", ""))"
+    scaleX = get(entity, "scaleX", 1.0)
+    scaleY = get(entity, "scaleY", 1.0)
+
+    Ahorn.drawSprite(ctx, sprite, 0, 0, sx=scaleX, sy=scaleY)
+end
+
+function Ahorn.flipped(entity::MaskedDecal, horizontal::Bool)
+    if horizontal
+        entity.scaleX *= -1.0
+    else
+        entity.scaleY *= -1.0
+    end
+    return entity
+end
+
+animationRegex = r"\D+0*?$"
+filterAnimations(s::String) = occursin(animationRegex, s)
+
+function decalTextures()
+    Ahorn.loadChangedExternalSprites!()
+    textures = Ahorn.spritesToDecalTextures(Ahorn.getAtlas("Gameplay"))
+    filter!(filterAnimations, textures)
+    sort!(textures)
+    return textures
+end
+
+Ahorn.editingOptions(entity::MaskedDecal) = Dict{String, Any}(
+    "texture" => decalTextures()
+)
+
+end

--- a/Entities/MaskedDecal.cs
+++ b/Entities/MaskedDecal.cs
@@ -1,0 +1,72 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod.Cil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.StrawberryJam2021.Entities {
+    [Tracked]
+    [CustomEntity("SJ2021/MaskedDecal")]
+    public class MaskedDecal : Entity {
+        private static BlendState DestinationAlphaBlend = new BlendState {
+            ColorSourceBlend = Blend.DestinationAlpha,
+            ColorDestinationBlend = Blend.InverseSourceAlpha,
+            AlphaSourceBlend = Blend.Zero,
+            AlphaDestinationBlend = Blend.One,
+            AlphaBlendFunction = BlendFunction.Add
+        };
+
+        public Decal Decal;
+
+        public MaskedDecal(EntityData data, Vector2 offset) : base(data.Position + offset) {
+            Decal = new Decal(data.Attr("texture"), Position, new Vector2(data.Float("scaleX", 1f), data.Float("scaleY", 1f)), Depths.FGDecals);
+            Decal.Visible = false;
+        }
+
+        public override void Added(Scene scene) {
+            base.Added(scene);
+            scene.Add(Decal);
+        }
+
+
+        public static void Load() {
+            IL.Celeste.Level.Render += Level_Render;
+        }
+
+        public static void Unload() {
+            IL.Celeste.Level.Render -= Level_Render;
+        }
+
+        private static void Level_Render(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+
+            while (cursor.TryGotoNext(MoveType.After,
+                instr => instr.MatchLdfld<Level>("GameplayRenderer"),
+                instr => instr.MatchLdarg(0),
+                instr => instr.MatchCallvirt<Renderer>("Render"))) {
+
+                Logger.Log("StrawberryJam2021/MaskedDecal", "Added Level.Render IL hook");
+
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate<Action<Level>>(level => {
+
+                    List<Entity> maskedDecals = level.Tracker.GetEntities<MaskedDecal>();
+                    if (maskedDecals.Count > 0) {
+                        Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, DestinationAlphaBlend, SamplerState.PointWrap, DepthStencilState.None, RasterizerState.CullNone, null, level.Camera.Matrix);
+                        foreach (MaskedDecal entity in maskedDecals) {
+                            entity.Decal?.Render();
+                        }
+                        Draw.SpriteBatch.End();
+                    }
+
+                });
+            }
+        }
+    }
+}

--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -20,11 +20,13 @@ namespace Celeste.Mod.StrawberryJam2021 {
         public override void Load() {
             SelfUpdater.Load();
             BubbleCollider.Load();
+            MaskedDecal.Load();
         }
 
         public override void Unload() {
             SelfUpdater.Unload();
             BubbleCollider.Unload();
+            MaskedDecal.Unload();
         }
 
         public override void LoadContent(bool firstLoad) {


### PR DESCRIPTION
Example of two mask decals properly ignoring the styleground, a fading out pink decal and a blue curvy line decal:
![screen-006197](https://user-images.githubusercontent.com/39496523/109078472-9d4d1000-76ba-11eb-838e-952630c287db.png)

Closes #34.