### PR TITLE
fix a crash when using VortexHelper's BowlPuffers

### DIFF
--- a/Entities/AntiGravJelly.cs
+++ b/Entities/AntiGravJelly.cs
@@ -218,7 +218,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         }
 
         private static void patchPlayerThrow(On.Celeste.Player.orig_Throw orig, Player self) {
-            if (self.Holding.Entity is AntiGravJelly && Input.MoveY.Value == 1 && Input.MoveX.Value != 0) {
+            if (self.Holding?.Entity is AntiGravJelly && Input.MoveY.Value == 1 && Input.MoveX.Value != 0) {
                 Input.Rumble(RumbleStrength.Strong, RumbleLength.Short);
                 self.Holding.Release(Vector2.UnitX * (float) self.Facing);
                 self.Speed.X = self.Speed.X + 08f * (float) -(float) self.Facing;


### PR DESCRIPTION
VortexHelpers BowlPuffers call Player.Throw when exploding, which (used to) result in a NullReferenceException because Player.Holding was null

![image](https://user-images.githubusercontent.com/11347524/110212544-1eb35800-7e9c-11eb-8fea-9071a9ee952c.png)
