### PR TITLE
Fix cursed macOS issues by making structs not readonly

### DIFF
--- a/Entities/CassetteConveyorBlock.cs
+++ b/Entities/CassetteConveyorBlock.cs
@@ -67,7 +67,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             Teleport(conveyorState.MoveThisFrame ? previousIndex : conveyorState.Index);
         }
 
-        private readonly struct ConveyorState {
+        private struct ConveyorState {
             public readonly int Index;
             public readonly bool MoveThisFrame;
 

--- a/Entities/CassetteTimedBlock.cs
+++ b/Entities/CassetteTimedBlock.cs
@@ -45,7 +45,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             }
         }
 
-        protected readonly struct CassetteTimerState {
+        protected struct CassetteTimerState {
             public readonly int Beat;
             public readonly bool ChangedSinceLastBeat;
 


### PR DESCRIPTION
Starting up a few mods including Communal Helper and Strawberry Jam leads to [this kind of crash](https://cdn.discordapp.com/attachments/429775439423209472/826194208025083924/crash.txt). This was fixed in Communal Helper by making sure no struct was readonly (don't ask why, I don't know either); this PR applies the same change to Strawberry Jam. My macOS VM now gives me FNA3D crashes instead, which might just be related to it being a VM.