### PR TITLE
Fixed hooks and death animation color for DashCountTrigger

### DIFF
--- a/Triggers/DashCountTrigger.cs
+++ b/Triggers/DashCountTrigger.cs
@@ -54,6 +54,7 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
             On.Celeste.PlayerHair.GetHairColor -= modPlayerGetHairColor;
             On.Celeste.Player.GetCurrentTrailColor -= modPlayerGetTrailColor;
             On.Celeste.Player.Die -= modDie;
+            Everest.Events.Level.OnExit -= modOnExit;
             On.Celeste.DeathEffect.Draw -= modDraw;
             On.Celeste.Level.LoadLevel -= modPlayerRespawn;
         }


### PR DESCRIPTION
It now correctly disables the modded functions when in another map, and the deathanimation color is the right color when you have no dashes. These are issues some playtesters and the mapper have run into and are now fixed, I also tested it with invincibilty enabled which worked fine. I also deleted the Batteries.dll which I accidentally placed here.