### PR TITLE
Add Rider workspace to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Rider
+.idea/


### PR DESCRIPTION
Sick of seeing `.idea` in my changes, as I'm sure other Rider users would be.