### PR TITLE
Fixed error with missing player

### DIFF
--- a/Triggers/DashCountTrigger.cs
+++ b/Triggers/DashCountTrigger.cs
@@ -117,7 +117,6 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
             if (ResetOnDeath && IsInCurrentMap && playerIntro == Player.IntroTypes.Respawn) {
                 Player player = level.Tracker.GetEntity<Player>();
                 if (player != null) {
-                    player = level.Tracker.GetEntity<Player>();
                     player.SceneAs<Level>().Session.Inventory.Dashes = NormalDashAmount;
                     player.Dashes = NormalDashAmount;
                 }


### PR DESCRIPTION
Now checks if the player is null in ModDraw, so you don't get any crashes/