### PR TITLE
make spikes as lenient as dream blocks

### DIFF
--- a/Entities/DashThroughSpikes.cs
+++ b/Entities/DashThroughSpikes.cs
@@ -156,7 +156,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         //returns bool based on if the player is still dash type state, 
         //and their direction is toward the spikes in at least 1 direction
         private bool DashingIntoSpikes(Player player) {
-            return (player.StateMachine.State == Player.StDash 
+            return (player.DashAttacking
+                || player.StateMachine.State == Player.StDash 
                 || player.StateMachine.State == Player.StRedDash
                 || player.StateMachine.State == Player.StDreamDash)
                 && (Math.Sign(player.DashDir.X) == -Math.Sign(directionVector.X) 


### PR DESCRIPTION
Checks if "player.DashAttacking" (same check for dream block collision) in addition to other states, giving the spikes some forgiveness. 