### PR TITLE
Gravity Generator Trigger Fixes

### DIFF
--- a/Entities/FlagBreakerBox.cs
+++ b/Entities/FlagBreakerBox.cs
@@ -38,7 +38,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             musicProgress = -1;
             SurfaceSoundIndex = 9;
             start = Position;
-            this.sprite = GFX.SpriteBank.Create("flagBreakerBox");
+
+            if (GFX.SpriteBank.Has("flagBreakerBox"))
+                this.sprite = GFX.SpriteBank.Create("flagBreakerBox");
+            else
+                this.sprite = GFX.SpriteBank.Create("breakerBox");
             Sprite sprite = this.sprite;
             sprite.OnLastFrame = (Action<string>) Delegate.Combine(sprite.OnLastFrame, new Action<string>(delegate (string anim) {
                 if (anim == "break") {


### PR DESCRIPTION
An issue was quickly found when the triggers overlapped/were immediately adjacent.

This had to do with the fact that the value to revert to was set when the player entered it, but if the player was already in another flag trigger partially, it would cause the value to revert to to be set to the value of the other trigger.

Fixed by checking for other triggers that the player was touching on entry/exit. If the player enters another trigger when touching one already, the new one copies the value to revert to of the old one. If the player leaves a trigger while touching multiple, it doesn't reset the current flag value.

In addition, added a fallback sprite (the breaker box sprite) in the case that a map doesn't define flagBreakerBox in sprites.xml (so it doesn't crash).