### PR TITLE
Fix Barrier Dash Switch crashing when using a subclass of Glider

### DIFF
--- a/Entities/BarrierDashSwitch.cs
+++ b/Entities/BarrierDashSwitch.cs
@@ -78,7 +78,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         private static void DestroyIfBarrierDashSwitch(Glider glider, Platform hit) {
             if (hit is BarrierDashSwitch) {
-                DynamicData gliderData = new DynamicData(glider);
+                DynamicData gliderData = new DynamicData(typeof(Glider), glider);
                 gliderData.Set("destroyed", true);
                 glider.Collidable = false;
                 glider.Add(new Coroutine(gliderData.Invoke<IEnumerator>("DestroyAnimationRoutine")));


### PR DESCRIPTION
Apparently DestroyAnimationRoutine couldn't be found if the type was inferred to be a subclass of Glider, which would cause a weird crash from the coroutine being null. Changing the DynamicData to actually use the Glider type was able to fix it. (Thank you max480)