### PR TITLE
Add "Disable Camera Lock" option to Crystal Bomb Badeline Boss

### DIFF
--- a/Ahorn/entities/crystalBombBadelineBoss.jl
+++ b/Ahorn/entities/crystalBombBadelineBoss.jl
@@ -4,7 +4,8 @@ using ..Ahorn, Maple
 
 @mapdef Entity "SJ2021/CrystalBombBadelineBoss" CrystalBombBadelineBoss(x::Integer, y::Integer, 
     nodes::Array{Tuple{Integer, Integer}, 1}=Tuple{Integer, Integer}[], patternIndex::Integer=1, 
-    cameraPastY::Number=120.0, cameraLockY::Bool=true, canChangeMusic::Bool=true, music::String="")
+    cameraPastY::Number=120.0, cameraLockY::Bool=true, canChangeMusic::Bool=true, music::String="",
+    disableCameraLock::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Badeline Boss (Crystal Bomb)\n(Strawberry Jam 2021)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -92,3 +92,4 @@ placements.entities.SJ2021/CrystalBombBadelineBoss.tooltips.patternIndex=Determi
 placements.entities.SJ2021/CrystalBombBadelineBoss.tooltips.cameraLockY=Whether the camera should be locked vertically, functioning similarly as a killbox.
 placements.entities.SJ2021/CrystalBombBadelineBoss.tooltips.canChangeMusic=Whether the boss should be able to change the music to the boss track.
 placements.entities.SJ2021/CrystalBombBadelineBoss.tooltips.cameraPastY=Locks the camera from vertically rising, and changes the bottom screen killbox plane to be under Badeline's current position.
+placements.entities.SJ2021/CrystalBombBadelineBoss.tooltips.disableCameraLock=Disables all camera locking, both horizontal and vertical.\nOverrides the "Camera Past Y" and "Camera Lock Y" settings.

--- a/Entities/CrystalBombBadelineBoss.cs
+++ b/Entities/CrystalBombBadelineBoss.cs
@@ -37,6 +37,9 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             Add(new PlayerCollider(OnPlayer, playerCollider));
 
             music = data.Attr("music", "");
+            if (data.Bool("disableCameraLock")) {
+                Remove(Get<CameraLocker>());
+            }
         }
 
         public override void Update() {


### PR DESCRIPTION
At PugRoy's request, added an Ahorn attribute to Crystal Bomb Badeline Boss (#38) that will prevent the boss from locking the camera in any way.