### PR TITLE
Added 'Constant Speed' option for Toggle Blocks

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -125,3 +125,5 @@ placements.entities.SJ2021/StrawberryJamJar.tooltips.sprite=The sprite this jar 
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.oscillate=Whether block reverses direction instead of returning to start after reaching its last node.  Ignored if "Stop At End" is checked.
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.stopAtEnd=Whether block doesn't move again after reaching its last node.
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.customTexturePath=Path to a 24 pixel x 24 pixel texture representing what a 3 tile x 3 tile block should look like.  Default texture is used if left blank.
+placements.entities.SJ2021/ToggleSwapBlock.tooltips.directionIndicator=If checked, the block displays an indicator showing the direction it will move next.
+placements.entities.SJ2021/ToggleSwapBlock.tooltips.constantSpeed=If checked, the velocity of the block will be the same each time it moves, and not scale with the distance between nodes.  Furthermore, "Travel Speed" will be interpretted as a multiplier, with 1.0 corresponding to vanilla swap block speed.

--- a/Entities/ToggleSwapBlock.cs
+++ b/Entities/ToggleSwapBlock.cs
@@ -7,7 +7,7 @@ using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
 
 namespace Celeste.Mod.StrawberryJam2021.Entities {
-    public static class ToggleBlockReskin {
+    public static class ToggleSwapBlock {
         private const int STAY = 8, DONE = 9;
         private static string[] paths = new string[] { "right", "downRight", "down", "downLeft", "left", "upLeft", "up", "upRight", "stay", "done" };
         private static string pathPrefix = "objects/StrawberryJam2021/toggleIndicator/";
@@ -16,20 +16,27 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private static MethodInfo getNextNode = toggleSwapBlockType.GetMethod("GetNextNode", BindingFlags.NonPublic | BindingFlags.Instance);
         private static MethodInfo recalculateLaserColor = toggleSwapBlockType.GetMethod("RecalculateLaserColor", BindingFlags.NonPublic | BindingFlags.Instance);
         private static MethodInfo drawBlockStyle = toggleSwapBlockType.GetMethod("DrawBlockStyle", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static MethodInfo updateTexture = typeof(ToggleBlockReskin).GetMethod("UpdateTexture", BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod(toggleSwapBlockType);
-        private static MethodInfo drawTexture = typeof(ToggleBlockReskin).GetMethod("DrawTexture", BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod(toggleSwapBlockType);
-        private static Hook updateTextureHook;
+        private static MethodInfo updateTextureAndSpeed = typeof(ToggleSwapBlock).GetMethod("UpdateTextureAndSpeed", BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod(toggleSwapBlockType);
+        private static MethodInfo drawTexture = typeof(ToggleSwapBlock).GetMethod("DrawTexture", BindingFlags.NonPublic | BindingFlags.Static).MakeGenericMethod(toggleSwapBlockType);
+        private static Hook updateTextureAndSpeedHook;
         private static Hook drawTextureHook;
 
-        private class TextureComponent : Component {
+        private class DataComponent : Component {
+            public readonly bool isReskin;
+            public readonly bool isConstant;
+            public readonly float speed;
             public MTexture texture;
 
-            public TextureComponent() : base(false, false) { }
+            public DataComponent(bool isReskin, bool isConstant, float speed) : base(false, false) {
+                this.isReskin = isReskin;
+                this.isConstant = isConstant;
+                this.speed = speed;
+            }
         }
 
         public static void Load() {
             Everest.Events.Level.OnLoadEntity += OnLoadEntity;
-            updateTextureHook = new Hook(recalculateLaserColor, updateTexture);
+            updateTextureAndSpeedHook = new Hook(recalculateLaserColor, updateTextureAndSpeed);
             drawTextureHook = new Hook(drawBlockStyle, drawTexture);
         }
 
@@ -41,56 +48,68 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public static void Unload() {
             Everest.Events.Level.OnLoadEntity -= OnLoadEntity;
-            updateTextureHook.Dispose();
+            updateTextureAndSpeedHook.Dispose();
             drawTextureHook.Dispose();
         }
 
         private static bool OnLoadEntity(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
-            bool isReskin = entityData.Name == "SJ2021/ToggleSwapBlock";
-            if (isReskin) {
+            bool isSJToggleBlock = entityData.Name == "SJ2021/ToggleSwapBlock";
+            if (isSJToggleBlock) {
+                bool isReskin = entityData.Bool("directionIndicator", true);
+                bool isConstant = entityData.Bool("constantSpeed", false);
+                float speed = 360f * entityData.Float("travelSpeed", 1f);
+                Component dataComponent = new DataComponent(isReskin, isConstant, speed);
                 Entity block = (Entity) Activator.CreateInstance(toggleSwapBlockType, new object[] { entityData, offset });
-                block.Add(new TextureComponent());
+                block.Add(dataComponent);
                 level.Add(block);
             }
-            return isReskin;
+            return isSJToggleBlock;
         }
 
-        private static void UpdateTexture<ToggleSwapBlock>(Action<ToggleSwapBlock> orig, ToggleSwapBlock self) where ToggleSwapBlock : Entity {
+        private static void UpdateTextureAndSpeed<ToggleSwapBlock>(Action<ToggleSwapBlock> orig, ToggleSwapBlock self) where ToggleSwapBlock : Entity {
             orig(self);
-            TextureComponent texComp = self.Get<TextureComponent>();
-            if (texComp == null) {
+            DynData<ToggleSwapBlock> data = new DynData<ToggleSwapBlock>(self);
+
+            DataComponent dataComp = self.Get<DataComponent>();
+            if (dataComp == null) {
                 return;
             }
-            DynData<ToggleSwapBlock> data = new DynData<ToggleSwapBlock>(self);
             Vector2[] nodes = data.Get<Vector2[]>("nodes");
             int currNode = data.Get<int>("nodeIndex");
             int nextNode = (int) getNextNode.Invoke(self, new object[] { currNode });
-            bool stopAtEnd = data.Get<bool>("stopAtEnd");
-            int indicator;
-            if (stopAtEnd && currNode == nodes.Length - 1) {
-                indicator = DONE;
-            } else {
-                Vector2 dir = nodes[nextNode] - nodes[currNode];
-                if (dir.Equals(Vector2.Zero)) {
-                    indicator = STAY;
+            Vector2 dir = nodes[nextNode] - nodes[currNode];
+
+            if (dataComp.isReskin) {
+                bool stopAtEnd = data.Get<bool>("stopAtEnd");
+                int indicator;
+                if (stopAtEnd && currNode == nodes.Length - 1) {
+                    indicator = DONE;
                 } else {
-                    indicator = (int) Math.Round(dir.Angle() * (4 / Math.PI));
-                    if (indicator < 0) {
-                        indicator += 8;
+                    if (dir.Equals(Vector2.Zero)) {
+                        indicator = STAY;
+                    } else {
+                        indicator = (int) Math.Round(dir.Angle() * (4 / Math.PI));
+                        if (indicator < 0) {
+                            indicator += 8;
+                        }
                     }
                 }
+                dataComp.texture = textures[indicator];
             }
-            texComp.texture = textures[indicator];
+
+            if (dataComp.isConstant) {
+                data.Set("travelSpeed", dataComp.speed / dir.Length());
+            }
         }
 
         private static void DrawTexture<ToggleSwapBlock>(Action<ToggleSwapBlock, Vector2, float, float, MTexture[,], Sprite, Color> orig,
             ToggleSwapBlock self, Vector2 pos, float width, float height, MTexture[,] ninSlice, Sprite middle, Color color) where ToggleSwapBlock : Entity {
-            TextureComponent texComp = self.Get<TextureComponent>();
-            if (texComp == null) {
+            DataComponent dataComp = self.Get<DataComponent>();
+            if (dataComp == null || !dataComp.isReskin) {
                 orig(self, pos, width, height, ninSlice, middle, color);
             } else {
                 orig(self, pos, width, height, ninSlice, null, color);
-                texComp.texture.DrawCentered(pos + self.Center - self.Position);
+                dataComp.texture.DrawCentered(pos + self.Center - self.Position);
             }
         }
     }

--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -36,7 +36,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             BarrierDashSwitch.Load();
             TripleBoostFlower.Load();
             ResettingRefill.Load();
-            ToggleBlockReskin.Load();
+            ToggleSwapBlock.Load();
         }
 
         public override void Unload() {
@@ -56,7 +56,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             BarrierDashSwitch.Unload();
             TripleBoostFlower.Unload();
             ResettingRefill.Unload();
-            ToggleBlockReskin.Unload();
+            ToggleSwapBlock.Unload();
         }
 
         public override void LoadContent(bool firstLoad) {
@@ -69,7 +69,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             SwitchCrateHolder.SetupParticles();
             LoopBlock.InitializeTextures();
             DashBoostField.LoadParticles();
-            ToggleBlockReskin.InitializeTextures();
+            ToggleSwapBlock.InitializeTextures();
         }
     }
 }


### PR DESCRIPTION
The Ahorn placement I made for the toggle block reskin now has separate options for adding directional indicators as Citrea requested and for having a constant speed as tofu requested, which can be enabled independently.

Closes #151.