### PR TITLE
Fixed bug with theo respawns considering respawns from the previous room

### DIFF
--- a/Entities/TheoRespawn.cs
+++ b/Entities/TheoRespawn.cs
@@ -46,6 +46,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             }
 
             scene.Add(new TheoCrystal(Position));
+            RemoveSelf();
         }
 
     }


### PR DESCRIPTION
Soloiini reported a bug as follows:

> Alright, so I finally figured out enough about a bug that seems to be happening with Theo respawns to be able to properly report it. Basically, it seems that if you die in a room, respawn, and then either throw Theo into the next room and enter it or go back into the previous room depending on the transition direction (e.g. right to left or left to right), Theo will not spawn until you die. However, you can still go back into the room Theo was left in freely (even through a right transition) and he will be there. If you retry after Theo has not appeared in the room, Theo will still respawn normally. Also weirdly, going through a right to left transition like this will keep all Theo temple gates open for some reason.
The exact conditions are a bit hard to explain through text, but if you play around with it you could probably figure it out better if needed. Basically though, if your most recent death was in room A, and you exit to room B without Theo then Theo will not spawn in until you die, although you can still go back to room A. If your most recent death was in room A, you go to room B with Theo, you throw Theo back into room A, and then enter room A then Theo should be there. I think that's everything, not sure how feasible it would be to fix it but still worth reporting for obvious reasons.

I was able to determine that this was caused by theo respawns considering the theo respawn used in the previous room, which was unexpected, but changing the theo respawn to remove itself after spawning theo cleared up the issue.