### PR TITLE
Fix Loop Block issue with CassetteFly player state

### DIFF
--- a/Entities/LoopBlock.cs
+++ b/Entities/LoopBlock.cs
@@ -240,7 +240,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             if (waiting) {
                 Player playerRider = GetPlayerRider();
-                if (playerRider != null) {
+                if (playerRider != null && playerRider.StateMachine.State != Player.StCassetteFly) {
                     canRumble = true;
                     speed.Y = 180f;
                     waiting = false;


### PR DESCRIPTION
Loop blocks were getting triggered upon colliding with a player in the `StCassetteFly` state.