### PR TITLE
Made Wonky Cassette Controller properly progress across freeze frames

### DIFF
--- a/Entities/WonkyCassetteBlockController.cs
+++ b/Entities/WonkyCassetteBlockController.cs
@@ -146,12 +146,12 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public static void Load() {
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
-            On.Celeste.Celeste.Freeze += Celeste_Freeze;
+            On.Monocle.Engine.Update += Engine_Update;
         }
 
         public static void Unload() {
             On.Celeste.Level.LoadLevel -= Level_LoadLevel;
-            On.Celeste.Celeste.Freeze -= Celeste_Freeze;
+            On.Monocle.Engine.Update -= Engine_Update;
         }
 
         private static void Level_LoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {
@@ -164,13 +164,14 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             }
         }
 
-        private static void Celeste_Freeze(On.Celeste.Celeste.orig_Freeze orig, float time) {
-            float oldFreezeTime = Engine.FreezeTimer;
+        private static void Engine_Update(On.Monocle.Engine.orig_Update orig, Engine self, GameTime gametime) {
+            float oldFreezeTimer = Engine.FreezeTimer;
 
-            orig(time);
+            orig(self, gametime);
 
-            if (oldFreezeTime < time) {
-                Engine.Scene.Tracker.GetEntity<WonkyCassetteBlockController>()?.AdvanceMusic(time - oldFreezeTime, Engine.Scene, StrawberryJam2021Module.Session);
+            if (!Engine.DashAssistFreeze && oldFreezeTimer > 0f) {
+                Engine.Scene.Tracker.GetEntity<WonkyCassetteBlockController>()?.AdvanceMusic(Engine.DeltaTime, Engine.Scene, StrawberryJam2021Module.Session);
+                Engine.Scene.Tracker.GetEntities<WonkyCassetteBlock>().ForEach(block => block.Update());
             }
         }
     }


### PR DESCRIPTION
With this change, Wonky Cassette Blocks and their controllers should now ~~hopefully~~ completely disregard freeze frames and update normally during them. Previously, they would halt progressing during freeze frames, meaning that music and cassette block updates would get slower the more the player dashes.

Vanilla Cassette Block Managers fast-forward their progress in `Celeste.Freeze` rather than updating separately; this works unless the player happens to cause freeze frames during which a transition to a new beat would happen. In that situation, the music would start playing up to two frames too early as the manager fast-forwards to the beat at the end of the freeze and starts playing it at the start of the freeze. The implementation done for wonky cassette blocks should not have this issue.

I am not aware of any side effects of updating entities outside of `Scene.Update`, but if there are any, please let me know.

Part of the never-ending #86.