### PR TITLE
Made Wonky Cassette Blocks with different OnAtBeats not connect

### DIFF
--- a/Entities/WonkyCassetteBlock.cs
+++ b/Entities/WonkyCassetteBlock.cs
@@ -46,16 +46,15 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 return;
             }
 
+            WonkyCassetteBlock selfCast = (WonkyCassetteBlock) self;
+
             var group = (List<CassetteBlock>) _groupField.GetValue(self);
 
             foreach (WonkyCassetteBlock entity in self.Scene.Tracker.GetEntities<WonkyCassetteBlock>().Cast<WonkyCassetteBlock>()) {
                 if (entity != self && entity != block && entity.Index == self.Index &&
                     (entity.CollideRect(new Rectangle((int) block.X - 1, (int) block.Y, (int) block.Width + 2, (int) block.Height))
-                        ? 1
-                        : entity.CollideRect(new Rectangle((int) block.X, (int) block.Y - 1, (int) block.Width, (int) block.Height + 2))
-                            ? 1
-                            : 0) != 0 &&
-                    !group.Contains(entity)) {
+                        || entity.CollideRect(new Rectangle((int) block.X, (int) block.Y - 1, (int) block.Width, (int) block.Height + 2))) &&
+                    !group.Contains(entity) && entity.OnAtBeats.SequenceEqual(selfCast.OnAtBeats)) {
                     group.Add(entity);
                     NewFindInGroup(orig, self, entity);
                     _groupField.SetValue(entity, group);
@@ -92,10 +91,13 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             if (!(self is WonkyCassetteBlock))
                 return origCheckForSame(self, x, y);
 
+            WonkyCassetteBlock selfCast = (WonkyCassetteBlock) self;
+
             return self.Scene.Tracker.GetEntities<WonkyCassetteBlock>()
                 .Cast<WonkyCassetteBlock>()
                 .Any(entity => entity.Index == self.Index
-                               && entity.Collider.Collide(new Rectangle((int) x, (int) y, 8, 8)));
+                               && entity.Collider.Collide(new Rectangle((int) x, (int) y, 8, 8))
+                               && entity.OnAtBeats.SequenceEqual(selfCast.OnAtBeats));
         }
 
         private static void CassetteBlock_SetImage(On.Celeste.CassetteBlock.orig_SetImage orig, CassetteBlock self, float x, float y, int tx, int ty) {


### PR DESCRIPTION
Adjacency checks are now also comparing the `OnAtBeats` parameter, so that adjacent ~~or overlapping~~ wonky cassette blocks that activate on different beats won't connect anymore.

Also cleaned up a bit of decompiler garbage.

Yes it's #86 once again.