### PR TITLE
Fix some cassette desyncs for cassette badeline blocks

### DIFF
--- a/Entities/CassetteTimedBlock.cs
+++ b/Entities/CassetteTimedBlock.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +31,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             // so, reflection saves the day again :)
             manager = scene.Tracker.GetEntity<CassetteBlockManager>();
 
-            if (manager != null) return;
+            if (manager != null)
+                return;
 
             List<Entity> toAdd = scene.Entities
                 .GetType().GetField("toAdd", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -63,7 +65,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             // This can happen in some edge cases when we're switching rooms and the manager is unloaded before us
             if (manager == null)
                 return null;
-            
+
             int beat = manager.GetSixteenthNote();
 
             beat = beat + cassetteResetOffset - 1;
@@ -81,6 +83,14 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 lastBeat = beat;
 
             return res;
+        }
+
+        protected int? GetCurrentIndex() {
+            // This can happen in some edge cases when we're switching rooms and the manager is unloaded before us
+            if (manager == null)
+                return null;
+
+            return new DynData<CassetteBlockManager>(manager).Get<int>("currentIndex");
         }
 
         protected float BeatsToSeconds(int beats) {

--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -47,6 +47,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             SkateboardTrigger.Load();
             LaserEmitter.Load();
             OshiroAttackTimeTrigger.Load();
+            CassetteBadelineBlock.Load();
         }
 
         public override void Unload() {
@@ -74,6 +75,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             SkateboardTrigger.Unload();
             LaserEmitter.Unload();
             OshiroAttackTimeTrigger.Unload();
+            CassetteBadelineBlock.Unload();
         }
 
         public override void LoadContent(bool firstLoad) {


### PR DESCRIPTION
Aims to fix #167 

The issue causing the desync is that the block assumed that "sixteenth note % 16 < 8" is equivalent to "currently active cassette block is blue". This is true... until you die. On reloading the level, there is a possibility the game changes the currently active block without touching the sixteenth note, and if it does, you get the opposite.

I fixed this by checking the "desynced" situation ("sixteenth note % 16 < 8 but currently active cassette block is purple" or the opposite), and applying an offset of 8 if that's the case. This way, asymmetric setups like "go to node at tick 4 and come back at tick 8" continue working.