### PR TITLE
Added 'Kill Maddy on Explosion' option to Switch Crate

### DIFF
--- a/Ahorn/entities/switchCrate.jl
+++ b/Ahorn/entities/switchCrate.jl
@@ -2,7 +2,7 @@ module SJ2021SwitchCrate
 
 using ..Ahorn, Maple
 
-@mapdef Entity "SJ2021/SwitchCrate" SwitchCrate(x::Integer, y::Integer, TimeToExplode::Number = 2.0, DepleteOnJumpThru::Bool = false)
+@mapdef Entity "SJ2021/SwitchCrate" SwitchCrate(x::Integer, y::Integer, TimeToExplode::Number = 2.0, DepleteOnJumpThru::Bool = false, KillMaddyOnExplosion::Bool = true)
 
 const placements = Ahorn.PlacementDict(
     "Switch Crate (Strawberry Jam 2021)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -186,3 +186,8 @@ placements.entities.SJ2021/WonkyCassetteBlockController.tooltips.boostFrames=The
 
 # Skateboard Trigger
 placements.triggers.SJ2021/SkateboardTrigger.tooltips.mode=Whether entering the trigger will enable, disable, or toggle the skateboard.
+
+# Switch Crate
+placements.entities.SJ2021/SwitchCrate.tooltips.TimeToExplode=The time (in seconds) it will take for the crate to explode.
+placements.entities.SJ2021/SwitchCrate.tooltips.DepleteOnJumpThru=Whether the explosion timer counts down when the crate is on a jumpthru (rather than on ground).
+placements.entities.SJ2021/SwitchCrate.tooltips.KillMaddyOnExplosion=Whether the player should be killed when the crate explodes. Madeline will die if the crate is squished or dropped out of the level regardless of this option.

--- a/Entities/SwitchCrate.cs
+++ b/Entities/SwitchCrate.cs
@@ -58,6 +58,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         bool DepleteOnJumpThru = false;
 
+        private bool KillMaddyOnExplosion;
+
         bool IsFirstFrame = true;
 
         bool HasStarted = false;
@@ -71,6 +73,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             TimeToExplode = data.Float("TimeToExplode", 1);
             DepleteOnJumpThru = data.Bool("DepleteOnJumpThru");
+            KillMaddyOnExplosion = data.Bool("KillMaddyOnExplosion", defaultValue: true);
 
             FlagName = "battery_" + data.ID;
             this.id = id;
@@ -81,7 +84,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             sprite = new Sprite(GFX.Game, "objects/StrawberryJam2021/SwitchCrate/");
             float t = 1f / 6f;
             sprite.Add("idle", "idle", t);
-            sprite.Rate = 1/ TimeToExplode;
+            sprite.Rate = 1 / TimeToExplode;
             Add(sprite);
             sprite.Play("idle", true);
 
@@ -106,9 +109,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             Tag = Tags.TransitionUpdate;
             Add(new MirrorReflection());
 
-            sprite.OnFinish = delegate
-            {
-                Die();
+            sprite.OnFinish = delegate {
+                Die(forceKillMaddy: false);
             };
         }
 
@@ -157,8 +159,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                                 Speed.Y = 0f;
                             }
                         }
-                    } else { 
-                        if(IsFirstFrame && !HasStarted) {
+                    } else {
+                        if (IsFirstFrame && !HasStarted) {
                             HasStarted = true;
                         }
                         Restartanim();
@@ -198,7 +200,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                         Speed.Y = -300f;
                         Audio.Play("event:/game/general/assist_screenbottom", Position);
                     } else if (Top > (float) Level.Bounds.Bottom) {
-                        Die();
+                        Die(forceKillMaddy: true);
                     }
                     if (X < (float) (Level.Bounds.Left + 10)) {
                         MoveH(32f * Engine.DeltaTime);
@@ -217,7 +219,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                     hitSeeker = null;
                 }
             }
-            if(IsHeld) {
+            if (IsHeld) {
                 Restartanim();
             }
             IsFirstFrame = false;
@@ -278,7 +280,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         }
 
         public bool OnSolidTile(int downCheck = 1) {
-            if(Collide.Check(this, Scene.Tracker.Entities[FloorBoosterType], Position + Vector2.UnitY * downCheck)) {
+            if (Collide.Check(this, Scene.Tracker.Entities[FloorBoosterType], Position + Vector2.UnitY * downCheck)) {
                 return false;
             }
             if (CollideCheckOutside<JumpThru>(Position + Vector2.UnitY * downCheck)) {
@@ -288,7 +290,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 return false;
             }
             if (!CollideCheck<SolidTiles>(Position + Vector2.UnitY * downCheck)) {
-                    return false;
+                return false;
             }
 
 
@@ -340,7 +342,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         protected override void OnSquish(CollisionData data) {
             if (!TrySquishWiggle(data, 3, 3) && !SaveData.Instance.Assists.Invincible) {
-                Die();
+                Die(forceKillMaddy: true);
             }
         }
 
@@ -351,7 +353,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             return false;
         }
 
-        public void Die() {
+        public void Die(bool forceKillMaddy) {
             if (!dead) {
                 dead = true;
                 Remove(Hold);
@@ -360,6 +362,10 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 sprite.Visible = false;
                 Depth = -1000000;
                 AllowPushing = false;
+
+                if (KillMaddyOnExplosion || forceKillMaddy) {
+                    Scene.Tracker.GetEntity<Player>()?.Die(Vector2.Zero);
+                }
             }
         }
 


### PR DESCRIPTION
A PR adding a new option to the switch crate entity (#87), following a request from Goldian. This allows killing the player when the crate explodes. When falling offscreen or being crushed, the crate kills the player regardless of that option.