### PR TITLE
Stop updating Switch Crates during transitions

### DIFF
--- a/Entities/SwitchCrate.cs
+++ b/Entities/SwitchCrate.cs
@@ -106,7 +106,6 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             Hold.OnCarry = pos => Position = pos + new Vector2(0f, -8f);
             LiftSpeedGraceTime = 0.1f;
             Add(new VertexLight(Collider.Center, Color.White, 1f, 32, 64));
-            Tag = Tags.TransitionUpdate;
             Add(new MirrorReflection());
 
             sprite.OnFinish = delegate {


### PR DESCRIPTION
Relates to #87 

Switch crates do not need to be updated during transitions, and it causes issues: the crates move towards the room you're transitioning to, and if you move up, the crate ends up below the (new) screen and you die during the transition, resulting in a crash.

Vanilla Theo Crystal has the same issue, the switch crate probably got it from there.