### PR TITLE
Fix laser sync flag carrying across into other rooms

### DIFF
--- a/Entities/LaserEmitter.cs
+++ b/Entities/LaserEmitter.cs
@@ -273,6 +273,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             base.Render();
         }
 
+        public override void Removed(Scene scene) {
+            setLaserSyncFlag(ColorChannel, false);
+            base.Removed(scene);
+        }
+
         private void onPlayerCollide(Player player) {
             var level = player.SceneAs<Level>();
 


### PR DESCRIPTION
Works similarly to how `LinkedZipMover`s disable their sync flag.

Related to #95 