### PR TITLE
Fix TAS desync in Dash Boost Field

### DIFF
--- a/Entities/DashBoostField.cs
+++ b/Entities/DashBoostField.cs
@@ -26,7 +26,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         public const float DefaultRadius = 1.5f;
 
         public static ParticleType P_RedRefill;
-        public static float CurrentTimeRateMult;
+        public static float CurrentTimeRateMult = 1f;
 
         private static BindingFlags privateInstance = BindingFlags.NonPublic | BindingFlags.Instance;
         private static MethodInfo dashCoroutineInfo = typeof(Player).GetMethod("DashCoroutine", privateInstance).GetStateMachineTarget();


### PR DESCRIPTION
This fixes a bug where TASes would desync if you ran them immediately after launching the game, because this was getting initialized to 0 for one frame when a level is first loaded.