### PR TITLE
Adding Ahorn parameters for custom start/stop audio

### DIFF
--- a/Ahorn/entities/ToggleSwapBlock.jl
+++ b/Ahorn/entities/ToggleSwapBlock.jl
@@ -3,7 +3,8 @@ module SJ2021ToggleSwapBlock
 using ..Ahorn, Maple
 
 @mapdef Entity "SJ2021/ToggleSwapBlock" ToggleBlock(width::Integer=16, height::Integer=16, travelSpeed::Number=5.0, oscillate::Bool=false, stopAtEnd::Bool=false,
-    directionIndicator::Bool=false, constantSpeed::Bool=false, customTexturePath::String="", customIndicatorPath::String="", disableTracks::Bool=false, allowDashSliding::Bool=false, accelerate::Bool=false)
+    directionIndicator::Bool=false, constantSpeed::Bool=false, customTexturePath::String="", customIndicatorPath::String="", disableTracks::Bool=false, allowDashSliding::Bool=false,
+    accelerate::Bool=false, customStartAudio::String="", customStopAudio::String="")
 
 function getXYWidthHeight(entity::ToggleBlock)
     x, y = Ahorn.position(entity)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -172,6 +172,8 @@ placements.entities.SJ2021/ToggleSwapBlock.tooltips.constantSpeed=If checked, th
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.customIndicatorPath=Path to a folder containing textures named "right", "downRight", "down", "downLeft", "left", "upLeft", "up", "upRight", "stay", and "done", which are displayed depending on the direction the block moves next, in place of the default indicators.  Built-in examples include "objects/StrawberryJam2021/toggleIndicator/plain/" (default), "objects/StrawberryJam2021/toggleIndicator/negative/", "objects/StrawberryJam2021/toggleIndicator/value/", "objects/StrawberryJam2021/toggleIndicator/sticker/".
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.disableTracks=Disables the tracks that appear along the path of the block.
 placements.entities.SJ2021/ToggleSwapBlock.tooltips.allowDashSliding=Allow player to slide on top of the block while dashing, instead of being fixed in place.
+placements.entities.SJ2021/ToggleSwapBlock.tooltips.customStartAudio=Custom audio to play when the block starts moving.  If blank, vanilla swap block sound is used.
+placements.entities.SJ2021/ToggleSwapBlock.tooltips.customStopAudio=Custom audio to play when the block stops moving.  If blank, vanilla swap block sound is used.
 
 # Wonky Cassette Block
 placements.entities.SJ2021/WonkyCassetteBlock.tooltips.onAtBeats=A list of integers (separated by a comma) corresponding to the beats on which this block should activate, being deactivated on all other beats not included in this list.\nExample: 1, 2, 4


### PR DESCRIPTION
I only implemented this for when the accelerate option is enabled because I had already hooked the movement for that and could easily replace the hardcoded vanilla audio, but I'll fix that when I finish making the blocks their own type separate from the canyon helper blocks.  Closes #249.