### PR TITLE
Fixed rare crash on death with wonky cassette controllers

### DIFF
--- a/Entities/WonkyCassetteBlockController.cs
+++ b/Entities/WonkyCassetteBlockController.cs
@@ -79,7 +79,9 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             isLevelMusic = AreaData.Areas[SceneAs<Level>().Session.Area.ID].CassetteSong == "-";
 
-            if (!isLevelMusic)
+            if (isLevelMusic)
+                sfx = Audio.CurrentMusicEventInstance;
+            else
                 snapshot = Audio.CreateSnapshot("snapshot:/music_mains_mute");
 
             StrawberryJam2021Session session = StrawberryJam2021Module.Session;
@@ -185,6 +187,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             if (isLevelMusic)
                 sfx = Audio.CurrentMusicEventInstance;
+
             if (!isLevelMusic && sfx == null) {
                 sfx = Audio.CreateInstance(AreaData.Areas[SceneAs<Level>().Session.Area.ID].CassetteSong);
                 Audio.Play("event:/game/general/cassette_block_switch_2");


### PR DESCRIPTION
Yep, that's right. It's #86 once again. Foolish to think it would be over.

A new room was added to the map, and it crashes in roughly 10% of deaths in that room because `sfx` isn't set before the first music progress update occurs. Strangely enough, this bug never triggers in any other room of the map, meaning something in that room is likely causing a freeze frame or something on the first frame after a respawn. Might be worth investigating separately.

This PR avoids the crash by not updating the music if that happens, and by trying to set the sfx in `Awake` if possible; I think this should be safe.