### PR TITLE
Fix missing using in StylegroundMask due to merge conflict

### DIFF
--- a/StylegroundMasks/StylegroundMask.cs
+++ b/StylegroundMasks/StylegroundMask.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Celeste.Mod.MaxHelpingHand.Effects;
+using Celeste.Mod.Entities;
 
 namespace Celeste.Mod.StrawberryJam2021.StylegroundMasks {
     [Tracked]


### PR DESCRIPTION
One branch removed unused usings, and another starting using one of them (Celeste.Mod.Entities)... so merging both of them together went 💥 