### PR TITLE
Add Auto-Skip Dialog Cutscene Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -334,3 +334,9 @@ placements.entities.SJ2021/PelletEmitterRight.tooltips.pelletCount=The number of
 placements.entities.SJ2021/PelletEmitterRight.tooltips.pelletDelay=The delay in seconds between each shot, if pelletCount is greater than 1. Defaults to 0.25.
 placements.entities.SJ2021/PelletEmitterRight.tooltips.cassetteIndex=The cassette swap index on which to fire. Defaults to 0.
 placements.entities.SJ2021/PelletEmitterRight.tooltips.collideWithSolids=Whether or not shots should collide with solids. Defaults to true.
+
+# Auto-Skip Dialog Cutscene Trigger (Everest)
+placements.triggers.SJ2021/AutoSkipDialogCutsceneTrigger.tooltips.onlyOnce=Whether the dialogue should only trigger once.
+placements.triggers.SJ2021/AutoSkipDialogCutsceneTrigger.tooltips.dialogId=The dialog ID to use for the dialogue.\nIn this dialogue, use {trigger 0} to start auto-skipping dialogue, and {trigger 1} to stop auto-skipping.
+placements.triggers.SJ2021/AutoSkipDialogCutsceneTrigger.tooltips.endLevel=Whether finishing the dialog triggers the level to end.
+placements.triggers.SJ2021/AutoSkipDialogCutsceneTrigger.tooltips.deathCount=Determines the exact amount of deaths required to activate dialog trigger. Will always trigger if set to -1.

--- a/Ahorn/triggers/autoSkipDialogCutsceneTrigger.jl
+++ b/Ahorn/triggers/autoSkipDialogCutsceneTrigger.jl
@@ -1,0 +1,15 @@
+﻿module SJ2021AutoSkipDialogCutsceneTrigger
+
+using ..Ahorn, Maple
+
+@mapdef Trigger "SJ2021/AutoSkipDialogCutsceneTrigger" AutoSkipDialogCutsceneTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
+    endLevel::Bool=false, onlyOnce::Bool=true, dialogId::String="", deathCount::Int=-1)
+
+const placements = Ahorn.PlacementDict(
+    "Auto-Skip Dialog Cutscene (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        AutoSkipDialogCutsceneTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/Triggers/AutoSkipDialogCutsceneTrigger.cs
+++ b/Triggers/AutoSkipDialogCutsceneTrigger.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.Utils;
+using System.Collections;
+
+namespace Celeste.Mod.Entities {
+    // Near copy-paste of Everest's Dialog Cutscene Trigger, that allows to start auto-skipping messages
+    // (skipping them without pressing Confirm) with {trigger 0} and stop auto-skipping with {trigger 1}.
+    [CustomEntity("SJ2021/AutoSkipDialogCutsceneTrigger")]
+    public class AutoSkipDialogCutsceneTrigger : Trigger {
+
+        private string dialogEntry;
+        private bool triggered;
+        private EntityID id;
+        private bool onlyOnce;
+        private bool endLevel;
+        private int deathCount;
+
+        public AutoSkipDialogCutsceneTrigger(EntityData data, Vector2 offset, EntityID entId)
+            : base(data, offset) {
+            dialogEntry = data.Attr("dialogId");
+            onlyOnce = data.Bool("onlyOnce", true);
+            endLevel = data.Bool("endLevel", false);
+            deathCount = data.Int("deathCount", -1);
+            triggered = false;
+            id = entId;
+        }
+
+        public override void OnEnter(Player player) {
+            if (triggered || (Scene as Level).Session.GetFlag("DoNotLoad" + id) ||
+                (deathCount >= 0 && SceneAs<Level>().Session.DeathsInCurrentLevel != deathCount)) {
+
+                return;
+            }
+
+            triggered = true;
+
+            Scene.Add(new AutoSkipDialogCutscene(dialogEntry, player, endLevel));
+
+            if (onlyOnce) {
+                (Scene as Level).Session.SetFlag("DoNotLoad" + id, true); // Sets flag to not load
+            }
+        }
+
+        private class AutoSkipDialogCutscene : CutsceneEntity {
+            private Player player;
+            private string dialogID;
+            private bool endLevel;
+
+            public AutoSkipDialogCutscene(string dialogID, Player player, bool endLevel) {
+                this.dialogID = dialogID;
+                this.player = player;
+                this.endLevel = endLevel;
+            }
+
+            public override void OnBegin(Level level) {
+                Add(new Coroutine(Cutscene(level)));
+            }
+
+            private IEnumerator Cutscene(Level level) {
+                player.StateMachine.State = 11;
+                player.StateMachine.Locked = true;
+                player.ForceCameraUpdate = true;
+                yield return Textbox.Say(dialogID, startSkipping, stopSkipping);
+                EndCutscene(level);
+            }
+
+            private IEnumerator startSkipping() {
+                new DynData<Textbox>(Scene.Tracker.GetEntity<Textbox>())["autoPressContinue"] = true;
+                yield break;
+            }
+
+            private IEnumerator stopSkipping() {
+                new DynData<Textbox>(Scene.Tracker.GetEntity<Textbox>())["autoPressContinue"] = false;
+                yield break;
+            }
+
+            public override void OnEnd(Level level) {
+                player.StateMachine.Locked = false;
+                player.StateMachine.State = 0;
+                player.ForceCameraUpdate = false;
+                if (WasSkipped) {
+                    level.Camera.Position = player.CameraTarget;
+                }
+                if (endLevel) {
+                    level.CompleteArea(true, false);
+                    player.StateMachine.State = 11;
+                    RemoveSelf();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a Dialog Cutscene Trigger that can skip dialog boxes without the player pressing Confirm.

Doesn't have a coding request attached, it was done quickly after a talk in collab_help with LegS since it's a slightly altered copy-paste of the Dialog Cutscene Trigger.

Example dialogue:

```
skeep=
	[MADELINE left normal]
	This is a skippy dialog cutscene.

	{trigger 0 skip}

	[MADELINE left normal]
	Time to skip

	{trigger 1 stop skipping}

	[BADELINE left scoff]
	This is looking pretty weird, isn't it?
```
