### PR TITLE
Made Wonky Cassette Blocks update during transitions and level freezes

### DIFF
--- a/Entities/WonkyCassetteBlock.cs
+++ b/Entities/WonkyCassetteBlock.cs
@@ -23,6 +23,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public WonkyCassetteBlock(Vector2 position, EntityID id, float width, float height, int index, string moveSpec, Color color, string textureDir)
             : base(position, id, width, height, index, 1.0f) {
+            Tag = Tags.FrozenUpdate | Tags.TransitionUpdate;
+
             OnAtBeats = Regex.Split(moveSpec, @",\s*").Select(int.Parse).Select(i => i - 1).ToArray();
 
             cassetteBlockData = new DynData<CassetteBlock>(this);

--- a/Entities/WonkyCassetteBlockController.cs
+++ b/Entities/WonkyCassetteBlockController.cs
@@ -30,11 +30,20 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private EventInstance sfx;
         private EventInstance snapshot;
 
+        private bool transitioningIn = false;
+
         public WonkyCassetteBlockController(EntityData data, Vector2 offset)
             : this(data.Position + offset, data.Int("bpm"), data.Int("bars"), data.Attr("timeSignature"), data.Attr("sixteenthNoteParam", "sixteenth_note"), data.Float("cassetteOffset"), data.Int("boostFrames", 1), data.Attr("disableFlag")) { }
 
         public WonkyCassetteBlockController(Vector2 position, int bpm, int bars, string timeSignature, string param, float cassetteOffset, int boostFrames, string disableFlag)
             : base(position) {
+            Tag = Tags.FrozenUpdate | Tags.TransitionUpdate;
+
+            Add(new TransitionListener() {
+                OnInBegin = () => transitioningIn = true,
+                OnInEnd = () => transitioningIn = false,
+            });
+
             this.bpm = bpm;
             this.bars = bars;
             this.param = param;
@@ -184,6 +193,9 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public override void Update() {
             base.Update();
+
+            if (transitioningIn)
+                return;
 
             if (isLevelMusic)
                 sfx = Audio.CurrentMusicEventInstance;


### PR DESCRIPTION
#86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 #86 ~~it never ends~~


Made cassette blocks update during room transitions, but made them only update at the end of rooms by manually disabling updates at the start of a room so as to not have double updates by both the old and the new controller. If you know of a better way to do this, please let me know.