### PR TITLE
Fixed NullRferenceException on Render when tracks disabled

### DIFF
--- a/Entities/ToggleSwapBlock.cs
+++ b/Entities/ToggleSwapBlock.cs
@@ -156,9 +156,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 					nineSliceBlock[j, k] = val3.GetSubtexture(new Rectangle(j * 8, k * 8, 8, 8));
 				}
 			}
-			laserCount = (oscillate || stopAtEnd || nodes.Length <= 2) ? nodes.Length - 1 : nodes.Length;
-			lasers = new ToggleBlockLaser[laserCount];
-			nodeTextures = new ToggleBlockNode[nodes.Length];
+			if (!disableTracks) {
+				laserCount = (oscillate || stopAtEnd || nodes.Length <= 2) ? nodes.Length - 1 : nodes.Length;
+				lasers = new ToggleBlockLaser[laserCount];
+				nodeTextures = new ToggleBlockNode[nodes.Length];
+			}
 		}
 
 		private string GetDefaultIfEmpty(EntityData data, string attrName, string defaultAttr) {
@@ -324,15 +326,17 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
 		public override void Render() {
 			int num = (oscillate || nodeIndex != nodes.Length - 1) ? ((!oscillate) ? (nodeIndex + 1) : ((nodeIndex == nodes.Length - 1) ? (nodeIndex - 1) : ((nodeIndex == 0) ? 1 : (nodeIndex + ((!returning) ? 1 : (-1)))))) : 0;
-			for (int i = 0; i < nodes.Length; i++) {
-				if (stopAtEnd && i == nodes.Length - 1) {
-					nodeTextures[i].color = endColor;
-				} else if (stopAtEnd && (i == 0 || (oscillate && i == nodes.Length - 2))) {
-					nodeTextures[i].color = offColor;
-				} else if (moving || stopped) {
-					nodeTextures[i].color = offColor;
-				} else {
-					nodeTextures[i].color = ((num == i) ? onColor : offColor);
+			if (!disableTracks) {
+				for (int i = 0; i < nodes.Length; i++) {
+					if (stopAtEnd && i == nodes.Length - 1) {
+						nodeTextures[i].color = endColor;
+					} else if (stopAtEnd && (i == 0 || (oscillate && i == nodes.Length - 2))) {
+						nodeTextures[i].color = offColor;
+					} else if (moving || stopped) {
+						nodeTextures[i].color = offColor;
+					} else {
+						nodeTextures[i].color = ((num == i) ? onColor : offColor);
+					}
 				}
 			}
 			DrawBlockStyle(Position + Shake, Width, Height, nineSliceBlock, null, Color.White);


### PR DESCRIPTION
Adding check that tracks are enabled before setting their color in Render().  I think what happened is that at one point I tried out a version that removed the tracks altogether but put them back when Citrea said they liked them and just copied from the decompiled code where they're enabled by default, and then that caused it to try to set the color of the tracks when they were null.  I didn't catch it initially, because apparently none of the blocks in my test rooms have tracks disabled, so that was my bad, but it looks like it works now.