### PR TITLE
Add support for type-targeted JellyGlowControllers

### DIFF
--- a/Ahorn/entities/jellyGlowController.jl
+++ b/Ahorn/entities/jellyGlowController.jl
@@ -9,7 +9,8 @@ using ..Ahorn, Maple
     lightStartFade::Integer=24,
     lightEndFade::Integer=48,
     lightOffsetX::Integer=0,
-    lightOffsetY::Integer=-10
+    lightOffsetY::Integer=-10,
+    targetEntityType::String=""
 )
 
 const placements = Ahorn.PlacementDict(
@@ -22,7 +23,8 @@ Ahorn.editingOrder(entity::JellyGlowController) = String[
     "x", "y", "width", "height",
     "lightColor", "lightAlpha",
     "lightStartFade", "lightEndFade",
-    "lightOffsetX", "lightOffsetY"
+    "lightOffsetX", "lightOffsetY",
+    "targetEntityType"
 ]
 
 const sprite = "objects/StrawberryJam2021/jellyGlowController/icon"

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -348,3 +348,4 @@ placements.entities.SJ2021/JellyGlowController.tooltips.lightStartFade=The dista
 placements.entities.SJ2021/JellyGlowController.tooltips.lightEndFade=The distance from the entity's position at which the light should begin to fade out.  Defaults to 48.
 placements.entities.SJ2021/JellyGlowController.tooltips.lightOffsetX=The X offset from the entity's position at which to place the light.  Defaults to 0 (the top centre of the hitbox).
 placements.entities.SJ2021/JellyGlowController.tooltips.lightOffsetY=The Y offset from the entity's position at which to place the light.  Defaults to -10 (the top centre of the hitbox).
+placements.entities.SJ2021/JellyGlowController.tooltips.targetEntityType=The entity class (without namespace) to affect.  Defaults to empty string, which matches Glider and all subclasses.

--- a/Entities/JellyGlowController.cs
+++ b/Entities/JellyGlowController.cs
@@ -11,6 +11,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private readonly int _lightStartFade;
         private readonly int _lightEndFade;
         private readonly Vector2 _lightOffset;
+        private readonly string _targetEntityType;
 
         public JellyGlowController(EntityData data, Vector2 offset)
             : base(data.Position + offset) {
@@ -19,13 +20,17 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             _lightStartFade = data.Int("lightStartFade", 24);
             _lightEndFade = data.Int("lightEndFade", 48);
             _lightOffset = new Vector2(data.Int("lightOffsetX"), data.Int("lightOffsetY", -10));
+            _targetEntityType = data.Attr("targetEntityType");
         }
 
         public override void Added(Scene scene) {
             base.Added(scene);
             var allGliders = scene.Entities.Concat(scene.Entities.GetToAdd()).OfType<Glider>();
+            bool wildcard = _targetEntityType == string.Empty;
             foreach (var glider in allGliders) {
-                glider.Add(new VertexLight(_lightOffset, _lightColor, _lightAlpha, _lightStartFade, _lightEndFade));
+                if (wildcard || glider.GetType().Name == _targetEntityType) {
+                    glider.Add(new VertexLight(_lightOffset, _lightColor, _lightAlpha, _lightStartFade, _lightEndFade));
+                }
             }
         }
     }


### PR DESCRIPTION
Related to #268.

Adds the ability to filter a controller to a single C# type (must be a `Glider` subclass).
Allows multiple controllers to be added to affect different glider types.
Leaving the `targetEntityType` empty will default to affecting `Glider` and all subclasses.