### PR TITLE
Change autobuild action to use ephemeral merge for pull requests

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,6 +1,10 @@
 name: Build using .NET Core
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
It means that:
* the build will only run for pull requests and pushes to `main`
* PR builds will always be against a working directory that includes a merge with `main`, avoiding post-merge compilation errors