### PR TITLE
Fix some bugs with ExpiringDashRefills

### DIFF
--- a/Entities/ExpiringDashRefill.cs
+++ b/Entities/ExpiringDashRefill.cs
@@ -65,9 +65,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public static PlayerDeadBody OnPlayerDeath(On.Celeste.Player.orig_Die orig, Player player, Vector2 direction, bool evenIfInvincible, bool registerDeathInStats) {
 
-            flash = false;
-            timeUntilDashExpire = 0;
-            player.Dashes = 0;
+            if (evenIfInvincible || !SaveData.Instance.Assists.Invincible) {
+                flash = false;
+                timeUntilDashExpire = 0;
+                player.Dashes = 0;
+            }
 
             return orig.Invoke(player, direction, evenIfInvincible, registerDeathInStats);
         }


### PR DESCRIPTION
Partially resolves #302, mainly the timer related problems.

Static variables are now used to keep track of the expiration timer, rather than each refill keeping its own timer, and subsequent refill grabs will just reset the timer, rather than leaving the old one ticking. A death hook is also added to reset things when the player dies.

I run into problems when the 0-dash hair color is changed via Hyperline, mainly due to Hyperline also utilizing `HairColorOverride`, causing the flashing to not work. <sub>Jem stated the 0-dash colors are set via MoreDasheline, but there doesn't seem to be an option to change 0-dash colors, so I picked the closest thing I can find</sub>