### PR TITLE
Add CoreToggleNoFlash + SetMetadataTrigger

### DIFF
--- a/Ahorn/entities/coreToggleNoFlash.jl
+++ b/Ahorn/entities/coreToggleNoFlash.jl
@@ -1,0 +1,54 @@
+module SJ2021CoreToggleNoFlash
+using ..Ahorn, Maple
+
+@mapdef Entity "SJ2021/CoreToggleNoFlash" CoreToggleNoFlash(x::Integer, y::Integer, onlyFire::Bool=false, onlyIce::Bool=false, persistent::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Core Mode Toggle No Flash - Fire (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        CoreToggleNoFlash,
+        "point",
+        Dict{String, Any}(
+            "onlyFire" => true
+        )
+    ),
+    "Core Mode Toggle No Flash - Ice (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        CoreToggleNoFlash,
+        "point",
+        Dict{String, Any}(
+            "onlyIce" => true
+        )
+    ),
+    "Core Mode Toggle No Flash - Both (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        CoreToggleNoFlash
+    ),
+)
+
+function switchSprite(entity::CoreToggleNoFlash)
+    onlyIce = get(entity.data, "onlyIce", false)
+    onlyFire = get(entity.data, "onlyFire", false)
+
+    if onlyIce
+        return "objects/coreFlipSwitch/switch13.png"
+
+    elseif onlyFire
+        return "objects/coreFlipSwitch/switch15.png"
+
+    else
+        return "objects/coreFlipSwitch/switch01.png"
+    end
+end
+
+function Ahorn.selection(entity::CoreToggleNoFlash)
+    x, y = Ahorn.position(entity)
+    sprite = switchSprite(entity)
+
+    return Ahorn.getSpriteRectangle(sprite, x, y)
+end
+
+function Ahorn.render(ctx::Ahorn.Cairo.CairoContext, entity::CoreToggleNoFlash, room::Maple.Room)
+    sprite = switchSprite(entity)
+
+    Ahorn.drawSprite(ctx, sprite, 0, 0)
+end
+
+end

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -229,6 +229,9 @@ placements.triggers.SJ2021/RainDensityTrigger.tooltips.duration=The time (in sec
 # Require Dashless Trigger
 placements.triggers.SJ2021/RequireDashlessTrigger.tooltips.entityNames=The class names of the entities to remove if the player has dashed as a comma-separated list.
 
+# Set Metadata Trigger
+placements.triggers.SJ2021/SetMetadataTrigger.tooltips.theoInBooster=Whether player is allowed to hold crystal Theo while in a booster or not.
+
 # Expiring Dash Refill
 placements.entities.SJ2021/ExpiringDashRefill.tooltips.dashExpirationTime=The amount of time given before the dash is revoked if not used.
 placements.entities.SJ2021/ExpiringDashRefill.tooltips.hairFlashThreshold=The threshold ratio that determines when the warning flash begins. (0 - 1)
@@ -379,3 +382,8 @@ placements.entities.SJ2021/FlagFloatySpaceBlock.tooltips.tiletype=The tileset to
 placements.entities.SJ2021/FlagFloatySpaceBlock.tooltips.disableSpawnOffset=Whether or not the entity should spawn without the random offset.
 placements.entities.SJ2021/FlagFloatySpaceBlock.tooltips.flag=The name of the flag that will activate the block.
 placements.entities.SJ2021/FlagFloatySpaceBlock.tooltips.moveTime=The time in seconds for the block to move to a new position.
+
+# Core Toggle No Flash
+placements.entities.SJ2021/CoreToggleNoFlash.tooltips.onlyIce=Whether the switch can only turn the core mode to ice.
+placements.entities.SJ2021/CoreToggleNoFlash.tooltips.onlyFire=Whether the switch can only turn the core mode to fire.
+placements.entities.SJ2021/CoreToggleNoFlash.tooltips.persistent=Whether the core mode persists after death instead of resetting to initial room entry state.

--- a/Ahorn/triggers/setMetadataTrigger.jl
+++ b/Ahorn/triggers/setMetadataTrigger.jl
@@ -1,0 +1,13 @@
+module SJ2021SetMetadataTrigger
+using ..Ahorn, Maple
+
+@mapdef Trigger "SJ2021/SetMetadataTrigger" SetMetadataTrigger(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, theoInBooster::Bool=false)
+
+const placements = Ahorn.PlacementDict(
+    "Set Metadata Trigger (Strawberry Jam 2021)" => Ahorn.EntityPlacement(
+        SetMetadataTrigger,
+        "rectangle"
+    )
+)
+
+end

--- a/Entities/CoreToggleNoFlash.cs
+++ b/Entities/CoreToggleNoFlash.cs
@@ -1,0 +1,40 @@
+﻿using Celeste.Mod.Entities;
+using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using System;
+
+namespace Celeste.Mod.StrawberryJam2021.Entities {
+    [CustomEntity("SJ2021/CoreToggleNoFlash")]
+    public class CoreToggleNoFlash : CoreModeToggle {
+
+        public CoreToggleNoFlash(Vector2 position, bool onlyFire, bool onlyIce, bool persistent)
+            : base(position, onlyFire, onlyIce, persistent) {
+        }
+
+        public CoreToggleNoFlash(EntityData data, Vector2 offset)
+            : this(data.Position + offset, data.Bool("onlyFire", false), data.Bool("onlyIce", false),
+                  data.Bool("persistent", false)) { }
+
+        public static void Load() {
+            IL.Celeste.CoreModeToggle.OnPlayer += CoreModeToggleOnPlayerHook;
+        }
+
+        public static void Unload() {
+            IL.Celeste.CoreModeToggle.OnPlayer -= CoreModeToggleOnPlayerHook;
+        }
+
+        private static void CoreModeToggleOnPlayerHook(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdcR4(0.15f))) {
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate<Func<float, CoreModeToggle, float>>((orig, toggle) => {
+                    if (toggle is CoreToggleNoFlash) {
+                        return 0f;
+                    }
+                    return orig;
+                });
+            }
+        }
+    }
+}

--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -64,6 +64,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             GroupedParallaxDecal.Load();
             ExpiringDashRefill.Load();
             ToggleSwapBlock.Load();
+            CoreToggleNoFlash.Load();
 
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
         }
@@ -104,6 +105,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             GroupedParallaxDecal.Unload();
             ExpiringDashRefill.Unload();
             ToggleSwapBlock.Unload();
+            CoreToggleNoFlash.Unload();
 
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
         }

--- a/Triggers/SetMetadataTrigger.cs
+++ b/Triggers/SetMetadataTrigger.cs
@@ -1,0 +1,21 @@
+using Celeste.Mod.Entities;
+using Celeste.Mod.Meta;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.StrawberryJam2021.Triggers {
+    [CustomEntity("SJ2021/SetMetadataTrigger")]
+    class SetMetadataTrigger : Trigger {
+
+        private bool theoInBooster;
+
+        public SetMetadataTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            theoInBooster = data.Bool("theoInBooster", false);
+        }
+
+        public override void OnEnter(Player player) {
+            base.OnEnter(player);
+            MapMetaModeProperties meta = SceneAs<Level>().Session.MapData.GetMeta();
+            meta.TheoInBubble = theoInBooster;
+        }
+    }
+}


### PR DESCRIPTION
Two small requests for Expert HS development:
1. Core Switch that just turns flash off (sets flash color to transparent)
2. Metadata trigger to set mod metadata info. Currently just Theo in Booster, could add other fields in future if other maps need them