### PR TITLE
SwitchCrateHolder takes crate no matter traveldirection

### DIFF
--- a/Entities/SwitchCrateHolder.cs
+++ b/Entities/SwitchCrateHolder.cs
@@ -163,7 +163,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         }
 
         public void Hit(SwitchCrate Crate, Vector2 direction) {
-            if (pressed || !(direction == pressDirection)) {
+            if (pressed) {
                 return;
             }
             Crate.Use();


### PR DESCRIPTION
I removed the part where it checks if the switch crate is coming right at the holder, so now it snaps in when it hits the holder no matter what.