### PR TITLE
Fix crash when changing between maps with masks

### DIFF
--- a/StylegroundMasks/StylegroundMask.cs
+++ b/StylegroundMasks/StylegroundMask.cs
@@ -156,7 +156,7 @@ namespace Celeste.Mod.StrawberryJam2021.StylegroundMasks {
                     }
                 }
             }
-            foreach (var i in bufferDict.Keys.Where((key) => !renderedKeys.Contains(key))) {
+            foreach (var i in bufferDict.Keys.Where((key) => !renderedKeys.Contains(key)).ToList()) {
                 bufferDict[i].Dispose();
                 bufferDict.Remove(i);
             }


### PR DESCRIPTION
Turns out that `.ToArray()` was needed because of dictionary enumerators crashing when their dictionary is mutated on .net framework :/