### PR TITLE
Unhardcode superboost lenience for SpeedPreservePuffer

### DIFF
--- a/Entities/SpeedPreservePuffer.cs
+++ b/Entities/SpeedPreservePuffer.cs
@@ -32,6 +32,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public static void Unload() {
             origUpdateHook?.Dispose();
+            origUpdateHook = null;
             IL.Celeste.Puffer.ctor_Vector2_bool -= onPufferConstructor;
             IL.Celeste.Puffer.Explode -= onPufferExplode;
         }


### PR DESCRIPTION
If you switch directions during the 0.01s lenience window, your speed gets hardcoded to 330, so we need to instead add the extra super boost speed to the players preserved speed.