### PR TITLE
Don't iterate entities if there is no show hitbox trigger in level

### DIFF
--- a/Triggers/ShowHitboxTrigger.cs
+++ b/Triggers/ShowHitboxTrigger.cs
@@ -90,6 +90,9 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
                 cursor.Emit(OpCodes.Ldarg_0); // self
                 cursor.Emit(OpCodes.Ldarg_1); // scene
                 cursor.EmitDelegate<Action<GameplayRenderer, Scene>>((self, scene) => {
+                    if (EnabledTypeNames.Count == 0) {
+                        return;
+                    }
                     foreach (Entity entity in scene.Entities) {
                         if (EnabledTypeNames.Contains(entity.GetType().FullName) || EnabledTypeNames.Contains(entity.GetType().Name)) {
                             entity.DebugRender(self.Camera);


### PR DESCRIPTION
Fixes performance issues in levels with lots of entities.