### PR TITLE
Specify base type in DynamicData where needed

### DIFF
--- a/Entities/BarrierDashSwitch.cs
+++ b/Entities/BarrierDashSwitch.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         public BarrierDashSwitch(Vector2 position, Sides side, bool persistent, EntityID id, string spritePath)
             : base(position, side, persistent, false, id, "default") {
             if (!string.IsNullOrEmpty(spritePath)) {
-                DynamicData baseData = new DynamicData(this);
+                DynamicData baseData = new DynamicData(typeof(DashSwitch), this);
                 Sprite sprite = baseData.Get<Sprite>("sprite");
                 Remove(sprite);
                 //sprites.xml cringe

--- a/Entities/BeeFireball.cs
+++ b/Entities/BeeFireball.cs
@@ -42,7 +42,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             this.offset = offset;
             mult = speedMult;
 
-            selfData = new DynamicData(this);
+            selfData = new DynamicData(typeof(FireBall), this);
 
             // replace fireball sprites with bee sprites
             sprite = Get<Sprite>();

--- a/Entities/CrystalBombBadelineBoss.cs
+++ b/Entities/CrystalBombBadelineBoss.cs
@@ -28,7 +28,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private static MethodInfo crystalBombExplodeHookInfo = typeof(CrystalBombBadelineBoss).GetMethod("On_CrystalBomb_Explode", BindingFlags.NonPublic | BindingFlags.Static);
 
         public CrystalBombBadelineBoss(EntityData data, Vector2 offset) : base(data, offset) {
-            baseData = new DynamicData(this);
+            baseData = new DynamicData(typeof(FinalBoss), this);
             // store original OnPlayer method so we can call it later...
             base_OnPlayer = Get<PlayerCollider>().OnCollide;
             // ...and then replace it for our boss

--- a/Entities/DirectionalBooster.cs
+++ b/Entities/DirectionalBooster.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private readonly Sprite sprite;
 
         public DirectionalBooster(EntityData data, Vector2 offset) : base(data.Position + offset, true) {
-            boosterData = new DynamicData(this);
+            boosterData = new DynamicData(typeof(Booster), this);
 
             // replace sprite
             Remove(boosterData.Get<Sprite>("sprite"));

--- a/Entities/NodedCloud.cs
+++ b/Entities/NodedCloud.cs
@@ -31,7 +31,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             nodes = data.Nodes;
             fadeInProgress = 1;
 
-            base_Entity = new DynamicData(this);
+            base_Entity = new DynamicData(typeof(Cloud), this);
             Add(ghost = new Image(GFX.Game["objects/clouds/fragile00"]));
             ghost.CenterOrigin();
             ghost.Color = Color.Black;

--- a/Entities/ResizableDashSwitch.cs
+++ b/Entities/ResizableDashSwitch.cs
@@ -74,7 +74,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
         public ResizableDashSwitch(Vector2 position, Sides side, bool persistent, EntityID id, int width, bool actLikeTouchSwitch, bool attachToSolid)
             : base(position, side, persistent, false, id, "default") {
-            baseData = new DynamicData(this);
+            baseData = new DynamicData(typeof(DashSwitch), this);
 
             Side = side;
             this.width = width;

--- a/Entities/SwitchDoor.cs
+++ b/Entities/SwitchDoor.cs
@@ -12,7 +12,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private Sprite sprite;
 
         public SwitchDoor(EntityData data, Vector2 offset, EntityID id) : base(data, offset, id) {
-            gateData = new DynamicData(this);
+            gateData = new DynamicData(typeof(BatteryGate), this);
             Remove(gateData.Get<Sprite>("sprite"));
             Add(sprite = StrawberryJam2021Module.SpriteBank.Create("switchDoor"));
             gateData.Set("sprite", sprite);

--- a/Entities/WonkyCassetteBlock.cs
+++ b/Entities/WonkyCassetteBlock.cs
@@ -31,7 +31,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             OnAtBeats = Regex.Split(moveSpec, @",\s*").Select(int.Parse).Select(i => i - 1).ToArray();
 
-            cassetteBlockData = new DynamicData(this);
+            cassetteBlockData = new DynamicData(typeof(CassetteBlock), this);
             cassetteBlockData.Set("color", color);
 
             this.textureDir = textureDir;

--- a/Entities/WormholeBooster.cs
+++ b/Entities/WormholeBooster.cs
@@ -41,7 +41,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             displacementMask.Stop();
             displacementMask.Visible = false;
 
-            boosterData = new DynamicData(this);
+            boosterData = new DynamicData(typeof(Booster), this);
             Remove(boosterData.Get<Sprite>("sprite"));
             Add(sprite = StrawberryJam2021Module.SpriteBank.Create("WormholeBooster"));
             sprite.Color = color;


### PR DESCRIPTION
Prevents conflict between similarly named fields (e.g. DirectionalBooster uses "sprite" and so does Booster)