### PR TITLE
Fix TogglePlaybacks setting defaults

### DIFF
--- a/StrawberryJam2021Settings.cs
+++ b/StrawberryJam2021Settings.cs
@@ -5,6 +5,6 @@ namespace Celeste.Mod.StrawberryJam2021 {
         public bool DisplayDashSequence { get; set; } = false;
 
         [DefaultButtonBinding(Buttons.Back, Keys.Tab)]
-        public ButtonBinding TogglePlaybacks { get; set; } = new ButtonBinding();
+        public ButtonBinding TogglePlaybacks { get; set; }
     }
 }


### PR DESCRIPTION
Making it a new ButtonBinding bypasses the Default attribute entirely, so remove that.
For the default to appear in-game, you'll need to remove your old SJ settings file(s).