### PR TITLE
Map-Global Loading of Entity

### DIFF
--- a/Entities/CrystallineHelperTimeFreezeMusicController.cs
+++ b/Entities/CrystallineHelperTimeFreezeMusicController.cs
@@ -7,11 +7,40 @@ using Monocle;
 using Microsoft.Xna.Framework;
 using System.Reflection;
 using Celeste.Mod.Entities;
+using MonoMod.Cil;
+using Mono.Cecil.Cil;
 
 namespace Celeste.Mod.StrawberryJam2021.Entities {
 
-    [CustomEntity("SJ2021/TimeFreezeMusicController")]
     public class CrystallineHelperTimeFreezeMusicController : Entity {
+
+        public static void Load() {
+            IL.Celeste.LevelLoader.LoadingThread += LevelLoader_LoadingThread;
+        }
+        public static void Unload() {
+            IL.Celeste.LevelLoader.LoadingThread -= LevelLoader_LoadingThread;
+        }
+
+        private static void LevelLoader_LoadingThread(ILContext il) {
+            ILCursor cursor = new ILCursor(il);
+            cursor.GotoNext(instr => instr.MatchRet());
+            if (cursor.TryGotoPrev(instr => instr.MatchLdarg(0), instr => instr.MatchLdcI4(1), instr => instr.MatchCallvirt<LevelLoader>("set_Loaded"))) {
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Emit(OpCodes.Call, typeof(CrystallineHelperTimeFreezeMusicController).GetMethod("LoadingThreadModifier", BindingFlags.Public|BindingFlags.Static));
+            }
+        }
+
+        public static void LoadingThreadModifier(LevelLoader loader) {
+            foreach (LevelData levelData in loader.Level.Session.MapData?.Levels) {
+                foreach (EntityData entityData in levelData.Entities) {
+                    if (entityData.Name == "SJ2021/TimeFreezeMusicController") {
+                        loader.Level.Add(new CrystallineHelperTimeFreezeMusicController(entityData, levelData.Position));
+                        return;
+                    }
+                }
+            }
+        }
+        
         
         public static FieldInfo crystallineHelper_TimeCrystal_stopStage;
 


### PR DESCRIPTION
Copypaste of code from VivHelper with some changes.

Safely loads the global TimeFreeze entity in the map if it exists anywhere in the MapData.
(LoadingThread IL hook ensures the *safety* by ensuring that it runs before the Level is finished loading, which causes some crashes in other helpers)