### PR TITLE
Fix for Cassette Music Transition Controller

### DIFF
--- a/Entities/CassetteMusicTransitionController.cs
+++ b/Entities/CassetteMusicTransitionController.cs
@@ -20,7 +20,9 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
                 if (listener != null) {
                     listener.OnOut = (time) => {
-                        manager.Update();
+                        if (manager.Scene != null) {
+                            manager.Update();
+                        }
                     };
                 }
             }


### PR DESCRIPTION
When you leave a room with the controller in it and enter a room that removes the cassette block manager (i.e. a room without cassette blocks), the game would crash if there is a component requiring the `Scene` attached to the entity. This change stops updates if the cassette block manager has been removed from the scene.