### PR TITLE
Make LightSourceLimitController more stable

### DIFF
--- a/StrawberryJam2021Session.cs
+++ b/StrawberryJam2021Session.cs
@@ -12,7 +12,6 @@ namespace Celeste.Mod.StrawberryJam2021 {
         public bool OshiroBSideMode = false;
         public bool SkateboardEnabled = false;
         public bool ZeroG = false;
-        public bool IncreaseLightSourceLimit = false;
 
         // ExpiringDashRefill stuff
         public double ExpiringDashRemainingTime;


### PR DESCRIPTION
Instead of replacing the lighting renderer when we find the controller, search the mapdata for a controller on level creation. Fixes some rare crashes where the renderer needs to be replaced at a bad time