### PR TITLE
Add option to have cassette blocks without any boost frames

### DIFF
--- a/Ahorn/entities/wonkyCassetteBlock.jl
+++ b/Ahorn/entities/wonkyCassetteBlock.jl
@@ -9,7 +9,7 @@ using ..Ahorn, Maple
     onAtBeats="1, 3",
     color::String="FFFFFF",
     textureDirectory::String="objects/cassetteblock",
-    boostFrames::Integer=0,
+    boostFrames::Integer=-1,
     controllerIndex::Integer=0,
 )
 

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -212,7 +212,7 @@ placements.entities.SJ2021/WindTunnelNoParticles.tooltips.strength=This value de
 placements.entities.SJ2021/WonkyCassetteBlock.tooltips.onAtBeats=A list of integers (separated by a comma) corresponding to the beats on which this block should activate, being deactivated on all other beats not included in this list.\nExample: 1, 2, 4
 placements.entities.SJ2021/WonkyCassetteBlock.tooltips.color=The hexadecimal colour code of this block (without the hash # symbol).
 placements.entities.SJ2021/WonkyCassetteBlock.tooltips.textureDirectory=The path to the folder containing two textures for this block, starting from Graphics/Atlases/Gameplay/. In order for this to work, the specified folder must containing two image files named "solid.png" and "pressed.png", each corresponding to the texture of the block when activated and deactivated respectively. Preferably without the "/" symbol at the end.
-placements.entities.SJ2021/WonkyCassetteBlock.tooltips.boostFrames=The number of frames after activation that a cassette boost is possible for. Must be at least 1 to be active. If set to 0 (default), will use boost frame count from the controller.
+placements.entities.SJ2021/WonkyCassetteBlock.tooltips.boostFrames=The number of frames after activation that a cassette boost is possible for. Must be at least 1 to be active. If set to -1 (default), will use boost frame count from the controller. If it is set to 0, cassette boosts will not be possible off of this block.
 placements.entities.SJ2021/WonkyCassetteBlock.tooltips.controllerIndex=The index of the controller that controls this cassette block. Must be 0 or greater. 0 refers to the main controller.
 
 # Wonky Cassette Block Controller


### PR DESCRIPTION
Ok you will never believe this but #86 is an issue that I have been working on for a while now and they wanted a new feature and I added it so I figured out IL for this and I sure am glad I have to work on game mechanics where single frame differences matter and make up the difference between good gameplay and garbage gameplay send help

Anyways this changes the default per-cassette-block override boost frames implemented in #311 from 0 to -1 which means it will have to be changed in all currently placed blocks with a script. Now -1 means "default to the controller's value", while 0 (the old default that used to mean what -1 means now) actually means "cassette boosts are disabled entirely". Because that is what I added. It appears to be working according to testers.