### PR TITLE
Hardcode teleport trigger use case for GMHS

### DIFF
--- a/Triggers/InstantTeleportTrigger.cs
+++ b/Triggers/InstantTeleportTrigger.cs
@@ -287,6 +287,7 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
 
                         //Sets the future values of the player. This code is modified from the Teleport Trigger to accommodate more things.
                         level.Session.Level = newRoom;
+                        level.Session.Dreaming = dreaming;
                         level.Session.FirstLevel = false;
 
                         level.Add(player);
@@ -296,8 +297,8 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
                     {
                         // triggered is set to false on load, because we're skipping reloading entities, we need to manually reset triggered
                         triggered = false;
+                        level.Session.Dreaming = dreaming;
                     }
-                    level.Session.Dreaming = dreaming;
 
                     if (!resetDashes) { player.Dashes = pDashes; }
                     if (newPos.X >= 0 && newPos.X <= level.Bounds.X + level.Bounds.Width - level.LevelOffset.X &&


### PR DESCRIPTION
The trigger will no longer reload entities when teleporting to the same room for alleviating loading lag on teleport in GMHS flag 1.

I also checked to make sure that this won't break any other places where it's used. The exhaustive list of this triggers usage is:
```! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (472, 856)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (168, 440)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (464, 240)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (520, 400)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (888, 272)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (1160, 488)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (1208, 984)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (880, 728)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1a - Found SJ2021/CustomInstantTeleportTrigger at (176, 880)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (1208, 984)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (880, 728)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (176, 880)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (464, 240)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (168, 440)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (520, 400)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (472, 856)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1b - Found SJ2021/CustomInstantTeleportTrigger at (888, 272)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (1208, 984)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (880, 728)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (176, 880)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (1160, 488)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (168, 440)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (520, 400)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (472, 856)
! Maps/StrawberryJam2021/3-Advanced/Oppen.bin - oppen_1c - Found SJ2021/CustomInstantTeleportTrigger at (888, 272)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - Start - Found SJ2021/CustomInstantTeleportTrigger at (1016, 224)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_a - Found SJ2021/CustomInstantTeleportTrigger at (328, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_a - Found SJ2021/CustomInstantTeleportTrigger at (240, 256)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_a - Found SJ2021/CustomInstantTeleportTrigger at (216, 0)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_a - Found SJ2021/CustomInstantTeleportTrigger at (200, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_b - Found SJ2021/CustomInstantTeleportTrigger at (64, 104)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_b - Found SJ2021/CustomInstantTeleportTrigger at (240, 256)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_b - Found SJ2021/CustomInstantTeleportTrigger at (200, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_b - Found SJ2021/CustomInstantTeleportTrigger at (328, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_c - Found SJ2021/CustomInstantTeleportTrigger at (64, 104)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_c - Found SJ2021/CustomInstantTeleportTrigger at (336, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_c - Found SJ2021/CustomInstantTeleportTrigger at (200, 288)
! Maps/StrawberryJam2021/3-Advanced/ZZ-HeartSide.bin - heartside_oppen_c - Found SJ2021/CustomInstantTeleportTrigger at (240, 256)
! Maps/StrawberryJam2021/4-Expert/Scroogle.bin - a-03 - Found SJ2021/MainInstantTeleportTrigger at (32, 7)
! Maps/StrawberryJam2021/4-Expert/Scroogle.bin - secret - Found SJ2021/MainInstantTeleportTrigger at (120, 543)
```

In Oppen_heimer's map, Scroogle's map, and Advanced Heartside, the teleport trigger is used to teleport to a different room, so the functionality stays exactly the same for them.