### PR TITLE
Add sink timer to launch platform

### DIFF
--- a/Entities/LaunchPlatform.cs
+++ b/Entities/LaunchPlatform.cs
@@ -10,8 +10,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         private readonly Vector2 start;
         private readonly Vector2 end;
         private readonly SoundSource sfx;
+        private float addY;
+        private float sinkTimer;
         
         private MTexture[] textures;
+        private PlatformState state = PlatformState.Start;
         
         public LaunchPlatform(Vector2 position, int width, Vector2 node) : base(position, width, false) {
             start = Position;
@@ -48,11 +51,31 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             textures[3].Draw(Position + new Vector2(Width - 8f, 0.0f));
             textures[2].Draw(Position + new Vector2((float) (Width / 2.0 - 4.0), 0.0f));
         }
+
+        public override void Update() {
+            base.Update();
+
+            if (HasPlayerRider()) {
+                sinkTimer = 0.2f;
+                addY = Calc.Approach(addY, 3f, 50f * Engine.DeltaTime);
+            } else if (sinkTimer > 0f) {
+                sinkTimer -= Engine.DeltaTime;
+                addY = Calc.Approach(addY, 3f, 50f * Engine.DeltaTime);
+            } else {
+                addY = Calc.Approach(addY, 0f, 20f * Engine.DeltaTime);
+            }
+
+            if (state is PlatformState.Start or PlatformState.End) {
+                var target = (state == PlatformState.Start ? start : end) + Vector2.UnitY * addY;
+                if (target != Position) MoveTo(target);
+            }
+        }
         
         // ReSharper disable IteratorNeverReturns
         private IEnumerator Sequence() {
             var platform = this;
             while (true) {
+                platform.state = PlatformState.Start;
                 while (!platform.HasPlayerRider()) {
                     yield return null;
                 }
@@ -61,30 +84,40 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 Input.Rumble(RumbleStrength.Medium, RumbleLength.Short);
                 platform.StartShaking(0.1f);
                 yield return 0.1f;
-                
+
+                platform.state = PlatformState.Launching;
                 float at = 0f;
                 while (at < 1f) {
                     yield return null;
                     at = Calc.Approach(at, 1f, 2f * Engine.DeltaTime);
-                    platform.MoveTo(Vector2.Lerp(start, end, Ease.CubeIn(at)));
+                    platform.MoveTo(Vector2.Lerp(start, end, Ease.CubeIn(at)) + Vector2.UnitY * platform.addY);
                 }
-                
+                platform.state = PlatformState.End;
+
                 platform.StartShaking(0.2f);
                 Input.Rumble(RumbleStrength.Strong, RumbleLength.Medium);
                 platform.SceneAs<Level>().Shake();
                 yield return 0.5f;
-                
+
+                platform.state = PlatformState.Returning;
                 at = 0f;
                 while (at < 1f) {
                     yield return null;
                     at = Calc.Approach(at, 1f, 0.5f * Engine.DeltaTime);
-                    platform.MoveTo(Vector2.Lerp(end, start, at));
+                    platform.MoveTo(Vector2.Lerp(end, start, at) + Vector2.UnitY * addY);
                 }
+                platform.state = PlatformState.Start;
                 
                 platform.StartShaking(0.2f);
-
                 yield return 0.5f;
             }
+        }
+
+        private enum PlatformState {
+            Start,
+            Launching,
+            End,
+            Returning,
         }
     }
 }


### PR DESCRIPTION
As requested by Phrog.

> Phrog — 25/11/2022
> Samah hey im finally implementing the custom launch platforms, they are great besides the fact they dont do the sinking thing so they feel very unnatural/old. would it be possible to do that? thanks

`MoveTo` for start and end states are handled in `Update`, launch and return states are handled in the coroutine since the position is lerped.