### PR TITLE
Fix first cassette block in a map being one pixel to low

### DIFF
--- a/Entities/WonkyCassetteBlockController.cs
+++ b/Entities/WonkyCassetteBlockController.cs
@@ -86,6 +86,24 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             session.CassetteBlocksDisabled = true;
         }
 
+        public void PrepareEnable(Scene scene, StrawberryJam2021Session session) {
+            var wonkyBlocks = scene.Tracker.GetEntities<WonkyCassetteBlock>().Cast<WonkyCassetteBlock>();
+
+            foreach (WonkyCassetteBlock wonkyBlock in wonkyBlocks) {
+                if (wonkyBlock.ControllerIndex == 0) {
+                    if (wonkyBlock.OnAtBeats.Contains(session.CassetteWonkyBeatIndex / (16 / beatLength) % barLength) != wonkyBlock.Activated) {
+                        wonkyBlock.WillToggle();
+                    }
+                } else {
+                    foreach (WonkyMinorCassetteBlockController minorController in Scene.Tracker.GetEntities<WonkyMinorCassetteBlockController>()) {
+                        if (wonkyBlock.ControllerIndex == minorController.ControllerIndex && wonkyBlock.OnAtBeats.Contains(minorController.CassetteWonkyBeatIndex / (16 / minorController.beatLength) % minorController.barLength) != wonkyBlock.Activated) {
+                            wonkyBlock.WillToggle();
+                        }
+                    }
+                }
+            }
+        }
+
         public override void Awake(Scene scene) {
             base.Awake(scene);
 
@@ -146,6 +164,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             } else if (session.CassetteBlocksDisabled && !shouldDisable) {
                 session.CassetteBlocksDisabled = false;
+
+                PrepareEnable(level, session);
             }
         }
 


### PR DESCRIPTION
For #86 because what else.

When loading a room that starts the cassette music for the first time, cassette blocks of the first colour in the room will be one pixel too low until a room load (room transition, death/retry, teleport) occurs. This is because those cassette blocks are only moved up by one pixel on frame 1, without having risen by one pixel in the background before as would be the case in all other situations. This PR forces them to rise by one pixel right before activating at the start of a map (or after the previous cassette track has been disabled).

> I sure am glad I have to work on game mechanics where single ~~frame~~ pixel differences matter and make up the difference between good gameplay and garbage gameplay