### PR TITLE
Fix persistence issue with Dash Count Trigger

### DIFF
--- a/Triggers/DashCountTrigger.cs
+++ b/Triggers/DashCountTrigger.cs
@@ -3,121 +3,103 @@ using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
-using System;
 
 namespace Celeste.Mod.StrawberryJam2021.Triggers {
-
-    [CustomEntity("SJ2021/DashCountTrigger")]
     [Tracked]
+    [CustomEntity("SJ2021/DashCountTrigger")]
     public class DashCountTrigger : Trigger {
-        //the static ones are the active settings, and the non-static ones are the settings of the trigger
-        private static bool IsInCurrentMap = false;
-        private static int NormalDashAmount = 1;
-        private static bool ResetOnDeath = false;
-        int NormalDashAmountSetting = 1;
-        int NumberOfDashesSetting = 1;
-        bool ResetOnDeathSetting = false;
+        private int origDashCount;
+        private readonly int newDashCount;
+        private bool entered;
 
-        public DashCountTrigger(EntityData data, Vector2 offset) : base(data, offset) {
-            NumberOfDashesSetting = data.Int("NumberOfDashes",1);
-            NormalDashAmountSetting = data.Int("DashAmountOnReset",1);
-            ResetOnDeathSetting = data.Bool("ResetOnDeath");
-        }
+        public DashCountTrigger(EntityData data, Vector2 offset)
+            : base(data, offset) {
+            newDashCount = data.Int("NumberOfDashes", 1);
 
-        public override void Added(Scene scene) {
-            base.Added(scene);
-            IsInCurrentMap = true;
+            // The persistence settings were removed, so these fields are no longer used.
+            //NormalDashAmountSetting = data.Int("DashAmountOnReset", 1);
+            //ResetOnDeathSetting = data.Bool("ResetOnDeath");
         }
 
         public override void OnEnter(Player player) {
             base.OnEnter(player);
-            SceneAs<Level>().Session.Inventory.Dashes = NumberOfDashesSetting;
-            player.Dashes = NumberOfDashesSetting;
-            ResetOnDeath = ResetOnDeathSetting;
-            NormalDashAmount = NormalDashAmountSetting;
-            RemoveSelf();
-        }
-
-        public static void Load() {
-            using (new DetourContext { After = { "*" } }) {
-                On.Celeste.PlayerHair.GetHairColor += modPlayerGetHairColor;
-                On.Celeste.Player.GetCurrentTrailColor += modPlayerGetTrailColor;
-                On.Celeste.Player.Die += modDie;
+            if (!entered) {
+                origDashCount = player.Inventory.Dashes;
+                SceneAs<Level>().Session.Inventory.Dashes = newDashCount;
+                player.Dashes = newDashCount;
+                entered = true;
             }
-            Everest.Events.Level.OnExit += modOnExit;
-            On.Celeste.DeathEffect.Draw += modDraw;
-            On.Celeste.Level.LoadLevel += modPlayerRespawn;
         }
 
-        public static void Unload() {
-            On.Celeste.PlayerHair.GetHairColor -= modPlayerGetHairColor;
-            On.Celeste.Player.GetCurrentTrailColor -= modPlayerGetTrailColor;
-            On.Celeste.Player.Die -= modDie;
-            Everest.Events.Level.OnExit -= modOnExit;
-            On.Celeste.DeathEffect.Draw -= modDraw;
-            On.Celeste.Level.LoadLevel -= modPlayerRespawn;
-        }
-
-        private static Color modPlayerGetHairColor(On.Celeste.PlayerHair.orig_GetHairColor orig, PlayerHair self, int index) {
-            if (self.Entity is Player player) {
-                if (IsInCurrentMap) {
-                    if (player.Dashes > 0) {
-                        return Player.NormalHairColor;
-                    }
-                    return Player.UsedHairColor;
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+            if (entered) {
+                if (scene.Tracker.GetEntity<Player>() is Player player && player.Inventory.Dashes == newDashCount) {
+                    (scene as Level).Session.Inventory.Dashes = origDashCount;
+                    player.Dashes = origDashCount;
                 }
             }
+        }
+
+        public override void SceneEnd(Scene scene) {
+            base.SceneEnd(scene);
+            if (entered) {
+                (scene as Level).Session.Inventory.Dashes = origDashCount;
+            }
+        }
+
+        internal static void Load() {
+            using (new DetourContext { After = { "*" } }) {
+                On.Celeste.PlayerHair.GetHairColor += ModPlayerGetHairColor;
+                On.Celeste.Player.GetCurrentTrailColor += ModPlayerGetTrailColor;
+                On.Celeste.Player.Die += ModDie;
+            }
+            On.Celeste.DeathEffect.Draw += ModDraw;
+        }
+
+        internal static void Unload() {
+            On.Celeste.PlayerHair.GetHairColor -= ModPlayerGetHairColor;
+            On.Celeste.Player.GetCurrentTrailColor -= ModPlayerGetTrailColor;
+            On.Celeste.Player.Die -= ModDie;
+            On.Celeste.DeathEffect.Draw -= ModDraw;
+        }
+
+        private static Color ModPlayerGetHairColor(On.Celeste.PlayerHair.orig_GetHairColor orig, PlayerHair self, int index) {
+            if (self.Entity is Player player && player.Scene.Tracker.GetEntity<DashCountTrigger>() != null) {
+                return player.Dashes > 0 ? Player.NormalHairColor : Player.UsedHairColor;
+            }
+
             return orig(self, index);
         }
 
-        private static Color modPlayerGetTrailColor(On.Celeste.Player.orig_GetCurrentTrailColor orig, Player self) {
-            if (self.Dashes > 0 && IsInCurrentMap) {
+        private static Color ModPlayerGetTrailColor(On.Celeste.Player.orig_GetCurrentTrailColor orig, Player self) {
+            if (self.Dashes > 0 && self.Scene.Tracker.GetEntity<DashCountTrigger>() != null) {
                 return Player.NormalHairColor;
-            } else {
-                return orig(self);
-            } 
+            }
+
+            return orig(self);
         }
 
-        private static PlayerDeadBody modDie(On.Celeste.Player.orig_Die orig, Player self, Vector2 direction, bool evenIfInvincible = false, bool registerDeathInStats = true) {
-            if (IsInCurrentMap) {
+        private static PlayerDeadBody ModDie(On.Celeste.Player.orig_Die orig, Player self, Vector2 direction, bool evenIfInvincible = false, bool registerDeathInStats = true) {
+            if (self.Scene.Tracker.GetEntity<DashCountTrigger>() != null) {
                 PlayerDeadBody Deadbody = orig(self, direction, evenIfInvincible, registerDeathInStats);
                 if (Deadbody != null) {
                     Color hairColor = (self.Dashes > 0) ? Player.NormalHairColor : Player.UsedHairColor;
                     new DynamicData(Deadbody).Set("initialHairColor", hairColor);             
                 }
+
                 return Deadbody;
             }
+
             return orig(self, direction, evenIfInvincible, registerDeathInStats);
         }
 
-        private static void modDraw(On.Celeste.DeathEffect.orig_Draw orig, Vector2 position, Color color, float ease) {
-            if (IsInCurrentMap) {
-                Player player = Engine.Scene.Tracker.GetEntity<Player>();
-                if(player != null) { 
-                    if (player.Dashes > 0) {
-                        color = Player.NormalHairColor;
-                    } else {
-                        color = Player.UsedHairColor;
-                    }
-                }
+        private static void ModDraw(On.Celeste.DeathEffect.orig_Draw orig, Vector2 position, Color color, float ease) {
+            if (Engine.Scene is Level level && level.Tracker.GetEntity<DashCountTrigger>() != null && level.Tracker.GetEntity<Player>() is Player player) {
+                color = player.Dashes > 0 ? Player.NormalHairColor : Player.UsedHairColor;
             }
+
             orig(position, color, ease);
-        }
-
-        private static void modOnExit(Level level, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
-            IsInCurrentMap = false;
-            ResetOnDeath = false;
-        }
-
-        private static void modPlayerRespawn(On.Celeste.Level.orig_LoadLevel orig, global::Celeste.Level level, global::Celeste.Player.IntroTypes playerIntro, bool isFromLoader) {
-            orig(level, playerIntro, isFromLoader);
-            if (ResetOnDeath && IsInCurrentMap && playerIntro == Player.IntroTypes.Respawn) {
-                Player player = level.Tracker.GetEntity<Player>();
-                if (player != null) {
-                    player.SceneAs<Level>().Session.Inventory.Dashes = NormalDashAmount;
-                    player.Dashes = NormalDashAmount;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
The persistence was causing an issue in BHS, so I just disabled the persistent settings. Hair color now only gets changed if the trigger is in the room, and dashes get reset when the trigger is unloaded. Verified working with BHS and owen's map.