### PR TITLE
Apply Glow Controller settings on Awake instead of Added

### DIFF
--- a/Entities/GlowController.cs
+++ b/Entities/GlowController.cs
@@ -45,8 +45,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             _bloomOffset = new Vector2(data.Int("bloomOffsetX"), data.Int("bloomOffsetY", -10));
         }
 
-        public override void Added(Scene scene) {
-            base.Added(scene);
+        public override void Awake(Scene scene) {
+            base.Awake(scene);
             var allEntities = scene.Entities.Concat(scene.Entities.GetToAdd());
             foreach (var entity in allEntities) {
                 var type = entity.GetType();


### PR DESCRIPTION
`Awake` happens right after `Added`, once all entities were added to the scene. This allows for it to apply even to entities that initialize their light/bloom in `Added`, like the mini hearts (since https://github.com/EverestAPI/CelesteCollabUtils2/commit/5ac03b352cfa94438bee29a0071f8703b7c672b1).