### PR TITLE
Implement wonky cassette block culling

### DIFF
--- a/Entities/WonkyCassetteBlock.cs
+++ b/Entities/WonkyCassetteBlock.cs
@@ -1,4 +1,5 @@
 using Celeste.Mod.Entities;
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -118,6 +119,11 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                     boostFrames -= 1;
                 }
             }
+        }
+
+        public override void Render() {
+            if (Utilities.IsRectangleVisible(Position.X, Position.Y, Width, Height))
+                base.Render();
         }
 
         private static bool NewCheckForSame(On.Celeste.CassetteBlock.orig_CheckForSame origCheckForSame, CassetteBlock self, float x, float y) {

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -92,5 +92,18 @@ namespace Celeste.Mod.StrawberryJam2021 {
             point.X <= self.Right + extend &&
             point.Y >= self.Top - extend &&
             point.Y <= self.Bottom + extend;
+
+        public static bool IsRectangleVisible(float x, float y, float w, float h) {
+            const float lenience = 4f;
+            Camera camera = (Engine.Scene as Level)?.Camera;
+            if (camera is null) {
+                return true;
+            }
+
+            return x + w >= camera.Left - lenience
+                && x <= camera.Right + lenience
+                && y + h >= camera.Top - lenience
+                && y <= camera.Bottom + 180f + lenience;
+        }
     }
 }


### PR DESCRIPTION
Due to some weird shenanigans:tm: with the shattersong shaders, the performinator doesn't really work for shattersong cassettes, so culling should be implemented directly in the entity. Spikes will be handled in a future everest PR.