### PR TITLE
Fix publicized field access exceptions on Mono (macOS/Linux)

### DIFF
--- a/StrawberryJam2021.csproj
+++ b/StrawberryJam2021.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Celeste.Mod.StrawberryJam2021</RootNamespace>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
     <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.exe')">..\..</CelestePrefix>
     <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>


### PR DESCRIPTION
Apparently Mono requires unsafe code to be enabled for publicized assemblies to play nicely at runtime.

Fixes crash on macOS and Linux introduced in #408 