### PR TITLE
Improve load times of wonky cassette blocks

### DIFF
--- a/Entities/WonkyCassetteBlockController.cs
+++ b/Entities/WonkyCassetteBlockController.cs
@@ -270,6 +270,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         }
 
         private static void Level_LoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {
+            WonkyCassetteBlock.Connections.Clear();
+
             orig(self, playerIntro, isFromLoader);
 
             StrawberryJam2021Session session = StrawberryJam2021Module.Session;


### PR DESCRIPTION
Currently, every wonky cassette block makes at least four calls to `CheckForSame` per 8x8 pixels of its area to determine which texture to use by checking whether there is a cassette block on each side of the current location. Each call of `CheckForSame` iterates through all wonky cassette blocks in the room and does a collision check with every block that has the same settings to determine whether it is connecting, amounting in four iterations through all cassette blocks per cassette block per 8x8 pixel area of the block.
This change completely replaces `CheckForSame` by creating a lookup dict of matrices, each the size of the current room (in tiles), that contain whether or not a specific position has a matching cassette block in it. The key of the dict is a string made up of all necessary pieces of information previously used to check whether two blocks should connect visually. This creates one connection matrix per cassette block configuration. The matrices are two tiles wider in each dimension than the room size to have one tile of "buffer" space around the room to make blocks that go out of bounds appear visually correct.
The matrices are generated once in the first call to `Awake` on room load, and then the potentially thousands of calls to `CheckForSame` are a simple dict lookup followed by an array access. The lookup dict is cleared at the start of `LoadLevel` in the controller's hook because I didn't want to make another hook just for this. If you have a better idea for where to populate and clear the connection matrices, let me know.
Overall, this virtually eliminates any performance impact of `CheckForSame` during room load, and shortens the load time of flag 1 in the heartside by 10% to 20%.

For #86.