### PR TITLE
More thorough fix for Grab Temple Gates

### DIFF
--- a/Entities/GrabTempleGate.cs
+++ b/Entities/GrabTempleGate.cs
@@ -101,7 +101,15 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
                 Y -= 64f - Collider.Height;
                 Collider.Height = 64f;
             }
-            MoveVNaive(height - num);
+
+            // check if the player is above the gate's top y level, and if so,
+            // perform a naive move down so as to not snap the player down, possibly killing it.
+            Player player = Scene.Tracker.GetEntity<Player>();
+            if (player.Bottom <= Bottom) // note: Bottom was Top before the collider was changed in the code above.
+                MoveVNaive(height - num);
+            else
+                MoveV(height - num);
+            
             Y = y;
             Collider.Height = height;
         }


### PR DESCRIPTION
the fix i ended up going for was the following:
 * check if the player is above the gate
 * if so: move the gate down naively, so that the player doesn't snap back down
 * otherwise, do the regular move, which can kill the player, as expected if it is standing below the gate.