### PR TITLE
Address remaining Solar Elevator issues and suggestions

### DIFF
--- a/Entities/SolarElevator.cs
+++ b/Entities/SolarElevator.cs
@@ -184,20 +184,26 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             if (Moving || (RequiresHoldable && !IsCarryingHoldable))
                 return;
 
-            Add(new Coroutine(Sequence()));
+            Add(new Coroutine(Sequence(player)));
+        }
+
+        private bool CanCarry(Holdable holdable) {
+            if (holdable.Entity is not Actor actor)
+                return false;
+
+            if (holdable.Holder?.IsRiding(this) ?? false)
+                return true;
+
+            if (actor.Left >= Left + 3 && actor.Right <= Right - 3 && actor.Bottom <= Bottom && actor.Top >= Top + 8)
+                return true;
+
+            return false;
         }
 
         private bool HoldableCheck() {
-            foreach (Holdable holdable in Scene.Tracker.GetComponents<Holdable>()) {
-                if (holdable.Entity is not Actor actor)
-                    continue;
-
-                if (holdable.Holder?.IsRiding(this) ?? false)
+            foreach (Holdable holdable in Scene.Tracker.GetComponents<Holdable>())
+                if (CanCarry(holdable))
                     return true;
-
-                if (actor.Left >= Left + 3 && actor.Right <= Right - 3 && actor.Bottom <= Bottom && actor.Top >= Top + 8)
-                    return true;
-            }
             return false;
         }
 
@@ -206,8 +212,18 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             IsCarryingHoldable = HoldableCheck();
         }
 
-        private IEnumerator Sequence() {
+        private IEnumerator Sequence(Player player) {
             Level level = SceneAs<Level>();
+
+            // drop the eventual holdable.
+            if (player.Holding is not null)
+                player.Drop();
+
+            // the player here is guaranteed to hold nothing.
+            // let's also make it impossible to hold any holdable during the elevator sequence.
+            foreach (Holdable holdable in Scene.Tracker.GetComponents<Holdable>())
+                if (CanCarry(holdable))
+                    holdable.cannotHoldTimer = delay + time;
 
             Moving = true;
             interaction.Enabled = false;


### PR DESCRIPTION
i was left with some suggestions and bugfixes to take care of, so here are the fixes:
  * if the elevator requires a holdable entity, then it checks for holdables that are either:
    * actively being carried by the player,
    * _inside_ the elevator, but not necessarily on the ground. (this prevents the elevator from being triggered with a holdable standing on top of the elevator, and also prevents the hint text from appearing and disappearing for a brief second when the holdable bounces as the elevator brutally stops).
  * prevent any interaction with holdables during the elevator sequence. when the elevator is triggered, any held holdable is dropped, and all holdables which satisfy the `HoldableCheck` method (criteria described above) are set to be unholdable for the time of the sequence (`delay + time`).