### PR TITLE
Fix MaskedOutline crash

### DIFF
--- a/Entities/MaskedOutline.cs
+++ b/Entities/MaskedOutline.cs
@@ -98,7 +98,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             if (parent is Booster) {
                 type = OutlineType.Booster;
             } else if (parent is Refill r){
-                type = r.twoDashes ? OutlineType.DoubleRefill : OutlineType.Refill; // yeah I know but this is faster
+                type = r.twoDashes ? OutlineType.DoubleRefill : OutlineType.Refill;
             }
             Setup();
         }


### PR DESCRIPTION
Couldn't replicate crash, I'm assuming the user wasusing a skin mod and the textures were not defined/had a nonstandard path setup? This is a safer method regardless