### PR TITLE
Add outline to triple boost flower

### DIFF
--- a/Entities/TripleBoostFlower.cs
+++ b/Entities/TripleBoostFlower.cs
@@ -337,5 +337,10 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
             speed.X *= -1f;
         }
 
+        public override void Render() {
+            if(sprite.Visible) sprite.DrawOutline();
+            base.Render();
+        }
+
     }
 }


### PR DESCRIPTION
Seems there was some confusion about artist intent with the triple boost flower, they should have outlines. This also fixes people confusing them for decals.