### PR TITLE
Grab Temple Gates + Freeze Frames

### DIFF
--- a/StrawberryJam2021Module.cs
+++ b/StrawberryJam2021Module.cs
@@ -75,6 +75,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             CS_Credits.Load();
             TasHelper.Load();
             GlowController.Load();
+            GrabTempleGate.Load();
 
             Everest.Events.Level.OnLoadBackdrop += onLoadBackdrop;
             On.Celeste.Player.OnSquish += Player_OnSquish;
@@ -126,6 +127,7 @@ namespace Celeste.Mod.StrawberryJam2021 {
             CS_Credits.Unload();
             TasHelper.Unload();
             GlowController.Unload();
+            GrabTempleGate.Unload();
 
             Everest.Events.Level.OnLoadBackdrop -= onLoadBackdrop;
             On.Celeste.Player.OnSquish -= Player_OnSquish;


### PR DESCRIPTION
* Allows Grab Temple Gates to be toggled ON or OFF during freeze frames. This is done by inserting additional logic in `Monocle.Engine.Update` with an IL hook.
* Minor tweaks and manual formatting

This entity is very probably going to be ported to [Communal Helper](https://github.com/CommunalHelper/CommunalHelper), but I think this still has to be merged so that the fix also takes place in Strawberry Jam