### PR TITLE
Fix "require dashless" trigger bug

### DIFF
--- a/Triggers/RequireDashlessTrigger.cs
+++ b/Triggers/RequireDashlessTrigger.cs
@@ -38,7 +38,7 @@ namespace Celeste.Mod.StrawberryJam2021.Triggers {
 
             Level level = SceneAs<Level>();
 
-            if (level.Session.Dashes != 0 || !level.Session.StartedFromBeginning) {
+            if (level.Session.Dashes != 0 || (!level.Session.StartedFromBeginning && !level.Session.RestartedFromGolden)) {
                 scene.Remove(trackedEntities);
                 removed = true;
             }

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: bin/StrawberryJam2021.dll
   Dependencies:
     - Name: Everest
-      Version: 1.3274.0
+      Version: 1.3847.0
     - Name: CavernHelper
       Version: 1.3.3
     - Name: MaxHelpingHand


### PR DESCRIPTION
Applies to Spoopy's map

Latest Everest version lets you check for golden restart sessions for things like dashless challenges (otherwise it breaks after a golden death when the golden/silver is not in the starting room)