### PR TITLE
Avoid potential compatability issues by not changing the stack type in PocketUmbrellaController

### DIFF
--- a/Entities/PocketUmbrellaController.cs
+++ b/Entities/PocketUmbrellaController.cs
@@ -66,7 +66,7 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
         }
 
         private static void ModForPocketUmbrella(ILCursor cursor) {
-            cursor.EmitDelegate<Func<Holdable, bool>>((h) => h == null ? false : !(h.Entity is not null && h.Entity is PocketUmbrella));
+            cursor.EmitDelegate<Func<Holdable, Holdable>>((h) => (h is null || h.Entity is PocketUmbrella) ? null : h);
         }
 
         private static void Engine_Update(ILContext il) {


### PR DESCRIPTION
Unsure why I didnt do it like this in the first place.

Changed the emitted delegate to the exact same one I use in the public version of this entity