### PR TITLE
Remove index++ usage

### DIFF
--- a/Entities/LightSourceLimitController.cs
+++ b/Entities/LightSourceLimitController.cs
@@ -62,7 +62,8 @@ namespace Celeste.Mod.StrawberryJam2021.Entities {
 
             if (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdcI4(VanillaRenderTargetBufferSize))) {
                 cursor.EmitDelegate<Func<int, int>>(GetLightBufferSize);
-                cursor.Index++;
+            }
+            if (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdcI4(VanillaRenderTargetBufferSize))) {
                 cursor.EmitDelegate<Func<int, int>>(GetLightBufferSize);
             }
         }


### PR DESCRIPTION
Apparently some other mod touches this code in a way that causes a crash. Unlucky. Seems to be low impact but we'll fix it in case another update happens.